### PR TITLE
fix: preserve Windows Harness entry paths

### DIFF
--- a/src-tauri/src/harness_command.rs
+++ b/src-tauri/src/harness_command.rs
@@ -1,0 +1,82 @@
+use std::{path::Path, process::Command};
+
+#[cfg(any(windows, test))]
+const WINDOWS_RUNTIME_ENTRY_ENV: &str = "DSH_DESKTOP_RESOLVED_ENTRY";
+#[cfg(any(windows, test))]
+const WINDOWS_RUNTIME_BOOTSTRAP: &str = "import{pathToFileURL}from'node:url';process.argv.splice(1,0,process.env.DSH_DESKTOP_RESOLVED_ENTRY);await import(pathToFileURL(process.env.DSH_DESKTOP_RESOLVED_ENTRY).href)";
+
+#[cfg(any(windows, test))]
+fn bootstrap_harness_command(node: &Path, entry: &Path) -> Command {
+    let mut command = Command::new(node);
+    command
+        .args([
+            "--input-type=module",
+            "--eval",
+            WINDOWS_RUNTIME_BOOTSTRAP,
+            "--",
+        ])
+        .env(WINDOWS_RUNTIME_ENTRY_ENV, entry);
+    command
+}
+
+#[cfg(windows)]
+pub(crate) fn harness_command(node: &Path, entry: &Path) -> Command {
+    bootstrap_harness_command(node, entry)
+}
+
+#[cfg(not(windows))]
+pub(crate) fn harness_command(node: &Path, entry: &Path) -> Command {
+    let mut command = Command::new(node);
+    command.arg(entry);
+    command
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs, path::Path, process, time::SystemTime};
+
+    use super::bootstrap_harness_command;
+
+    #[test]
+    fn bootstrap_preserves_a_spaced_entry_path_and_harness_arguments() {
+        let unique = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("test clock must follow the Unix epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "dsh desk spaced runtime test-{}-{unique}",
+            process::id()
+        ));
+        let entry = root.join("runtime entry.mjs");
+        fs::create_dir_all(&root).expect("spaced test directory must be created");
+        fs::write(
+            &entry,
+            "process.stdout.write(JSON.stringify(process.argv.slice(1)))\n",
+        )
+        .expect("test runtime entry must be written");
+
+        let node = if cfg!(windows) { "node.exe" } else { "node" };
+        let output = bootstrap_harness_command(Path::new(node), &entry)
+            .args(["web", "--port", "0"])
+            .output()
+            .expect("Node must execute the bootstrap command");
+
+        let _ = fs::remove_dir_all(&root);
+        assert!(
+            output.status.success(),
+            "bootstrap failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let arguments: Vec<String> =
+            serde_json::from_slice(&output.stdout).expect("bootstrap output must be JSON argv");
+        assert_eq!(
+            arguments,
+            [
+                entry.to_string_lossy().into_owned(),
+                "web".to_string(),
+                "--port".to_string(),
+                "0".to_string(),
+            ]
+        );
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+mod harness_command;
 mod plugin_manager;
 mod process_termination;
 mod runtime_supervisor;

--- a/src-tauri/src/plugin_manager.rs
+++ b/src-tauri/src/plugin_manager.rs
@@ -11,6 +11,8 @@ use flate2::read::GzDecoder;
 use serde::{Deserialize, Serialize};
 use tauri::Manager;
 
+use crate::harness_command::harness_command;
+
 const MAX_PLUGIN_ARCHIVE_BYTES: u64 = 50 * 1024 * 1024;
 const MAX_MANIFEST_BYTES: u64 = 1024 * 1024;
 const PROFILE_STATE_FILES: [&str; 3] = ["package.json", "pnpm-lock.yaml", "cordis.patch.yml"];
@@ -257,8 +259,7 @@ pub(crate) fn execute_plugin_command(
         .then(|| ProfileBackup::capture(profile_dir.clone()))
         .transpose()?;
 
-    let output = Command::new(node)
-        .arg(entry)
+    let output = harness_command(node, entry)
         .args(["plugin", "--profile", "web", request.action.as_str()])
         .arg(&request.operand)
         .current_dir(&workspace)
@@ -272,8 +273,7 @@ pub(crate) fn execute_plugin_command(
     let mut exit_code = output.status.code();
     let mut stderr = String::from_utf8_lossy(&output.stderr).into_owned();
     if success && request.is_mutating() {
-        let validation = Command::new(node)
-            .arg(entry)
+        let validation = harness_command(node, entry)
             .args(["--profile", "web", "--dump-config"])
             .current_dir(&workspace)
             .env("DSH_HOME", &home)

--- a/src-tauri/src/runtime_supervisor.rs
+++ b/src-tauri/src/runtime_supervisor.rs
@@ -19,6 +19,7 @@ use serde::Serialize;
 use tauri::{Emitter, Manager};
 use url::Url;
 
+use crate::harness_command::harness_command;
 use crate::plugin_manager::{
     PluginCommandRequest, PluginCommandResult, PluginInspection, execute_plugin_command,
     inspect_plugin_source,
@@ -443,9 +444,8 @@ fn start_runtime(app: &tauri::AppHandle) -> Result<RunningRuntime, RuntimeFailur
         &format!("starting runtime in {}", workspace.display()),
     );
 
-    let mut command = Command::new(&node);
+    let mut command = harness_command(&node, &entry);
     command
-        .arg(&entry)
         .args(["web", "--host", "127.0.0.1", "--port", "0"])
         .current_dir(workspace)
         .env("DSH_HOME", dsh_home)


### PR DESCRIPTION
## Summary
- launch the bundled Harness through a Windows-safe Node bootstrap
- preserve the resolved entry path and original Harness arguments
- reuse the launcher for plugin operations

## Validation
- Rust tests
- frontend and Rust checks
- development and packaged Harness contracts
- plugin parity contract
- live Windows verification with an install path containing spaces