### PR TITLE
fix: stage only complete release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
         include:
           - platform: macos
             runner: macos-15
-            tauri_args: '--bundles dmg'
+            tauri_args: '--bundles app,dmg'
           - platform: windows
             runner: windows-2022
             tauri_args: '--bundles nsis --config src-tauri/tauri.windows-signing.json'

--- a/scripts/lib/release-artifacts.mjs
+++ b/scripts/lib/release-artifacts.mjs
@@ -5,7 +5,7 @@ import {
   readFileSync,
   writeFileSync,
 } from "node:fs";
-import { basename, join, resolve } from "node:path";
+import { basename, extname, join, relative, resolve, sep } from "node:path";
 import { walkFiles } from "./files.mjs";
 
 const platformFiles = {
@@ -20,6 +20,21 @@ const platformFiles = {
     ".deb.sig",
   ],
 };
+
+const installerFolders = new Map([
+  [".dmg", "dmg"],
+  [".exe", "nsis"],
+  [".msi", "msi"],
+  [".appimage", "appimage"],
+  [".deb", "deb"],
+  [".rpm", "rpm"],
+]);
+
+export function isReleaseInstaller(bundleRoot, file) {
+  const parts = relative(resolve(bundleRoot), resolve(file)).split(sep);
+  const expectedFolder = installerFolders.get(extname(file).toLowerCase());
+  return parts.length === 2 && parts[0] === expectedFolder && !basename(file).startsWith("rw.");
+}
 
 export function stageReleaseArtifacts(platform, bundleRoot, outputDirectory) {
   const requiredSuffixes = platformFiles[platform];

--- a/scripts/test-release-artifacts.mjs
+++ b/scripts/test-release-artifacts.mjs
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { basename, join, resolve } from "node:path";
 import {
   assembleUpdateManifest,
+  isReleaseInstaller,
   stageReleaseArtifacts,
 } from "./lib/release-artifacts.mjs";
 
@@ -40,6 +41,12 @@ try {
   }
   const staged = stageReleaseArtifacts("linux", bundleRoot, stagedRoot);
   if (staged.length !== 6) throw new Error(`Expected 6 staged Linux artifacts, got ${staged.length}`);
+  if (!isReleaseInstaller(bundleRoot, join(bundleRoot, "appimage", "DSH.Desk.AppImage"))) {
+    throw new Error("Top-level AppImage installer was not recognized");
+  }
+  if (isReleaseInstaller(bundleRoot, join(bundleRoot, "appimage", "runtime", "helper.exe"))) {
+    throw new Error("Nested runtime executable was mistaken for a release installer");
+  }
   rmSync(bundleRoot, { recursive: true, force: true });
   rmSync(stagedRoot, { recursive: true, force: true });
 

--- a/scripts/test-updater-contract.mjs
+++ b/scripts/test-updater-contract.mjs
@@ -66,6 +66,7 @@ for (const token of [
   "tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f",
   "TAURI_SIGNING_PRIVATE_KEY",
   "TAURI_SIGNING_PRIVATE_KEY_PASSWORD",
+  "--bundles app,dmg",
   "needs: preflight",
   "uploadUpdaterJson: false",
   "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02",

--- a/scripts/write-release-checksums.mjs
+++ b/scripts/write-release-checksums.mjs
@@ -1,14 +1,11 @@
 import { createHash } from "node:crypto";
 import { createReadStream, writeFileSync } from "node:fs";
-import { basename, extname, resolve } from "node:path";
+import { basename, resolve } from "node:path";
 import { walkFiles } from "./lib/files.mjs";
+import { isReleaseInstaller } from "./lib/release-artifacts.mjs";
 
 const bundleRoot = resolve(import.meta.dirname, "../src-tauri/target/release/bundle");
-const releaseExtensions = new Set([".dmg", ".exe", ".msi", ".appimage", ".deb", ".rpm"]);
-
-const artifacts = walkFiles(bundleRoot).filter(
-  (path) => releaseExtensions.has(extname(path).toLowerCase()) && !basename(path).startsWith("rw."),
-);
+const artifacts = walkFiles(bundleRoot).filter((path) => isReleaseInstaller(bundleRoot, path));
 if (artifacts.length === 0) throw new Error(`No release artifacts found under ${bundleRoot}`);
 
 for (const artifact of artifacts) {


### PR DESCRIPTION
## Summary
- build the macOS updater archive alongside the human-installable DMG
- restrict checksums to top-level installer outputs, excluding bundled helper executables
- cover both constraints in the release contracts

## Why
The v0.1.0-alpha.4 run exposed both inherited issues: macOS produced no app updater archive, and Linux checksum upload collided on nested Windows helper filenames.

## Validation
- `pnpm test:updater-contract`
- `actionlint .github/workflows/release.yml`
- `git diff --check`