### PR TITLE
fix(release): verify notarized macOS DMG contents

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-desk",
   "private": true,
-  "version": "0.1.0-alpha.8",
+  "version": "0.1.0-alpha.9",
   "description": "Installable Tauri desktop distribution for DeepSeek Harness with a bundled runtime and daily compatibility checks.",
   "license": "MIT",
   "homepage": "https://github.com/majiayu000/dsh-desk/releases",

--- a/scripts/macos-release.mjs
+++ b/scripts/macos-release.mjs
@@ -178,16 +178,12 @@ function notarizeDmg() {
 function verifyDistribution() {
   if (!existsSync(dmgPath)) throw new Error(`Release artifact is missing: ${dmgPath}`);
 
-  let verifiedAppPath = appPath;
-  let mountPath;
+  const mountPath = mkdtempSync(join(tmpdir(), "dsh-desk-verify-"));
   try {
+    run("hdiutil", ["attach", "-nobrowse", "-readonly", "-mountpoint", mountPath, dmgPath]);
+    const verifiedAppPath = join(mountPath, "DSH Desk.app");
     if (!existsSync(verifiedAppPath)) {
-      mountPath = mkdtempSync(join(tmpdir(), "dsh-desk-verify-"));
-      run("hdiutil", ["attach", "-nobrowse", "-readonly", "-mountpoint", mountPath, dmgPath]);
-      verifiedAppPath = join(mountPath, "DSH Desk.app");
-      if (!existsSync(verifiedAppPath)) {
-        throw new Error(`Release application is missing from mounted DMG: ${verifiedAppPath}`);
-      }
+      throw new Error(`Release application is missing from mounted DMG: ${verifiedAppPath}`);
     }
 
     run("codesign", ["--verify", "--deep", "--strict", "--verbose=4", verifiedAppPath]);
@@ -217,12 +213,10 @@ function verifyDistribution() {
     ]);
     console.log(`Verified notarized macOS distribution with ${machOCount} Mach-O binaries`);
   } finally {
-    if (mountPath) {
-      try {
-        run("hdiutil", ["detach", mountPath]);
-      } finally {
-        rmSync(mountPath, { recursive: true, force: true });
-      }
+    try {
+      run("hdiutil", ["detach", mountPath]);
+    } finally {
+      rmSync(mountPath, { recursive: true, force: true });
     }
   }
 }

--- a/scripts/test-updater-contract.mjs
+++ b/scripts/test-updater-contract.mjs
@@ -108,6 +108,18 @@ assert(
   "Release artifact actions must be pinned to reviewed commits",
 );
 
+const macosRelease = read("scripts/macos-release.mjs");
+assert(
+  macosRelease.includes(
+    'run("hdiutil", ["attach", "-nobrowse", "-readonly", "-mountpoint", mountPath, dmgPath]);',
+  ),
+  "macOS verification must mount the shipped DMG",
+);
+assert(
+  !macosRelease.includes("let verifiedAppPath = appPath"),
+  "macOS verification must assess the app inside the shipped DMG, not the build directory",
+);
+
 const previewConfig = JSON.parse(read("src-tauri/tauri.unsigned-preview.json"));
 assert(
   previewConfig.bundle?.createUpdaterArtifacts === false,

--- a/site/index.html
+++ b/site/index.html
@@ -168,7 +168,7 @@
         </div>
 
         <div class="versions" aria-label="Pinned versions">
-          <dl class="version"><dt>DSH Desk</dt><dd data-desktop-version>0.1.0-alpha.8</dd></dl>
+          <dl class="version"><dt>DSH Desk</dt><dd data-desktop-version>0.1.0-alpha.9</dd></dl>
           <dl class="version"><dt>DeepSeek Harness</dt><dd data-harness-version>0.1.0-rc.6</dd></dl>
           <dl class="version version-updated"><dt>Evidence updated</dt><dd data-updated>waiting for GitHub</dd></dl>
         </div>

--- a/site/zh-CN/index.html
+++ b/site/zh-CN/index.html
@@ -168,7 +168,7 @@
         </div>
 
         <div class="versions" aria-label="固定版本">
-          <dl class="version"><dt>DSH Desk</dt><dd data-desktop-version>0.1.0-alpha.8</dd></dl>
+          <dl class="version"><dt>DSH Desk</dt><dd data-desktop-version>0.1.0-alpha.9</dd></dl>
           <dl class="version"><dt>DeepSeek Harness</dt><dd data-harness-version>0.1.0-rc.6</dd></dl>
           <dl class="version version-updated"><dt>验证更新时间</dt><dd data-updated>等待 GitHub 数据</dd></dl>
         </div>

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "dsh-desk"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 dependencies = [
  "base64 0.22.1",
  "flate2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dsh-desk"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 description = "A lightweight desktop shell for DeepSeek Harness"
 authors = ["DSH Desk contributors"]
 edition = "2024"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DSH Desk",
-  "version": "0.1.0-alpha.8",
+  "version": "0.1.0-alpha.9",
   "identifier": "ai.deepseek.harness.desk",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/plugin-catalog.json
+++ b/src/plugin-catalog.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "harnessVersion": "0.1.0-rc.6",
-  "desktopVersion": "0.1.0-alpha.8",
+  "desktopVersion": "0.1.0-alpha.9",
   "entries": [
     {
       "id": "web-search",


### PR DESCRIPTION
## Summary

- verify the application mounted from the shipped DMG instead of the build-directory copy
- retain Developer ID, notarization, stapler, codesign, and Gatekeeper checks
- bump the immutable release version to 0.1.0-alpha.9

## Validation

- `pnpm check`
- `pnpm test:rust` (19 passed)
- `pnpm test:updater-contract`
- `pnpm test:plugin-catalog`
- `pnpm test:status-page`
- `git diff --check`