### PR TITLE
fix(release): preserve both macOS updater architectures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,9 +240,11 @@ jobs:
         run: pnpm release:checksums
       - name: Stage immutable release artifacts
         shell: bash
-        run: >-
-          pnpm release:artifacts stage "${{ matrix.platform }}"
-          src-tauri/target/release/bundle "release-staging/${{ matrix.artifact }}"
+        run: |
+          version="$(node -p "require('./package.json').version")"
+          pnpm release:artifacts stage "${{ matrix.platform }}" \
+            src-tauri/target/release/bundle "release-staging/${{ matrix.artifact }}" \
+            "${{ matrix.artifact }}" "$version"
       - name: Record Windows signing metadata
         if: runner.os == 'Windows'
         env:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-desk",
   "private": true,
-  "version": "0.1.0-alpha.9",
+  "version": "0.1.0-alpha.10",
   "description": "Installable Tauri desktop distribution for DeepSeek Harness with a bundled runtime and daily compatibility checks.",
   "license": "MIT",
   "homepage": "https://github.com/majiayu000/dsh-desk/releases",

--- a/scripts/lib/release-artifacts.mjs
+++ b/scripts/lib/release-artifacts.mjs
@@ -36,7 +36,7 @@ export function isReleaseInstaller(bundleRoot, file) {
   return parts.length === 2 && parts[0] === expectedFolder && !basename(file).startsWith("rw.");
 }
 
-export function stageReleaseArtifacts(platform, bundleRoot, outputDirectory) {
+export function stageReleaseArtifacts(platform, bundleRoot, outputDirectory, options = {}) {
   const requiredSuffixes = platformFiles[platform];
   if (!requiredSuffixes) {
     throw new Error(`Unsupported release platform: ${platform}`);
@@ -49,6 +49,14 @@ export function stageReleaseArtifacts(platform, bundleRoot, outputDirectory) {
   }
   mkdirSync(destinationRoot, { recursive: true });
 
+  const macArchitecture = options.macArchitecture;
+  const version = options.version;
+  if (platform === "macos") {
+    if (!["aarch64", "x64"].includes(macArchitecture) || !version) {
+      throw new Error("macOS staging requires aarch64|x64 architecture and a version");
+    }
+  }
+
   const staged = [];
   for (const suffix of requiredSuffixes) {
     const matches = walkFiles(sourceRoot).filter(
@@ -59,7 +67,11 @@ export function stageReleaseArtifacts(platform, bundleRoot, outputDirectory) {
         `${platform} release requires exactly one ${suffix} artifact, found ${matches.length}`,
       );
     }
-    const destination = join(destinationRoot, basename(matches[0]));
+    const destinationName =
+      platform === "macos" && suffix.startsWith(".app.tar.gz")
+        ? `DSH Desk_${version}_${macArchitecture}${suffix}`
+        : basename(matches[0]);
+    const destination = join(destinationRoot, destinationName);
     if (existsSync(destination)) {
       throw new Error(`Refusing to overwrite staged release artifact: ${destination}`);
     }

--- a/scripts/release-artifacts.mjs
+++ b/scripts/release-artifacts.mjs
@@ -3,13 +3,18 @@ import { assembleUpdateManifest, stageReleaseArtifacts } from "./lib/release-art
 const [command, ...args] = process.argv.slice(2);
 
 if (command === "stage") {
-  const [platform, bundleRoot, outputDirectory] = args;
+  const [platform, bundleRoot, outputDirectory, artifact, version] = args;
   if (!platform || !bundleRoot || !outputDirectory) {
     throw new Error(
-      "Usage: node scripts/release-artifacts.mjs stage <macos|windows|linux> <bundle-root> <output-directory>",
+      "Usage: node scripts/release-artifacts.mjs stage <macos|windows|linux> <bundle-root> <output-directory> [artifact] [version]",
     );
   }
-  const staged = stageReleaseArtifacts(platform, bundleRoot, outputDirectory);
+  const macArchitecture =
+    artifact === "macos-arm64" ? "aarch64" : artifact === "macos-x64" ? "x64" : undefined;
+  const staged = stageReleaseArtifacts(platform, bundleRoot, outputDirectory, {
+    macArchitecture,
+    version,
+  });
   console.log(`Staged ${staged.length} ${platform} release artifacts.`);
 } else if (command === "manifest") {
   const [artifactDirectory, version, tag] = args;

--- a/scripts/test-release-artifacts.mjs
+++ b/scripts/test-release-artifacts.mjs
@@ -8,7 +8,7 @@ import {
 } from "./lib/release-artifacts.mjs";
 
 const directory = mkdtempSync(resolve(tmpdir(), "dsh-release-artifacts-"));
-const version = "0.1.0-alpha.9";
+const version = "0.1.0-alpha.10";
 const tag = `v${version}`;
 const signature = Buffer.from(
   "untrusted comment: test signature\nRWQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\ntrusted comment: test timestamp\nRWQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n",
@@ -50,6 +50,25 @@ try {
   }
   rmSync(bundleRoot, { recursive: true, force: true });
   rmSync(stagedRoot, { recursive: true, force: true });
+
+  const macBundleRoot = join(directory, "mac-bundle");
+  const stagedMacRoot = join(directory, "staged-mac");
+  mkdirSync(join(macBundleRoot, "nested"), { recursive: true });
+  for (const suffix of [".dmg", ".dmg.sha256", ".app.tar.gz", ".app.tar.gz.sig"]) {
+    writeFileSync(join(macBundleRoot, "nested", `DSH Desk${suffix}`), "fixture");
+  }
+  const stagedMac = stageReleaseArtifacts("macos", macBundleRoot, stagedMacRoot, {
+    macArchitecture: "aarch64",
+    version,
+  });
+  if (
+    !stagedMac.some((file) => file.endsWith(`_${version}_aarch64.app.tar.gz`)) ||
+    !stagedMac.some((file) => file.endsWith(`_${version}_aarch64.app.tar.gz.sig`))
+  ) {
+    throw new Error("macOS updater artifacts were not architecture-qualified before publishing");
+  }
+  rmSync(macBundleRoot, { recursive: true, force: true });
+  rmSync(stagedMacRoot, { recursive: true, force: true });
 
   const { manifest, output } = assembleUpdateManifest({
     artifactDirectory: directory,

--- a/site/index.html
+++ b/site/index.html
@@ -168,7 +168,7 @@
         </div>
 
         <div class="versions" aria-label="Pinned versions">
-          <dl class="version"><dt>DSH Desk</dt><dd data-desktop-version>0.1.0-alpha.9</dd></dl>
+          <dl class="version"><dt>DSH Desk</dt><dd data-desktop-version>0.1.0-alpha.10</dd></dl>
           <dl class="version"><dt>DeepSeek Harness</dt><dd data-harness-version>0.1.0-rc.6</dd></dl>
           <dl class="version version-updated"><dt>Evidence updated</dt><dd data-updated>waiting for GitHub</dd></dl>
         </div>

--- a/site/zh-CN/index.html
+++ b/site/zh-CN/index.html
@@ -168,7 +168,7 @@
         </div>
 
         <div class="versions" aria-label="固定版本">
-          <dl class="version"><dt>DSH Desk</dt><dd data-desktop-version>0.1.0-alpha.9</dd></dl>
+          <dl class="version"><dt>DSH Desk</dt><dd data-desktop-version>0.1.0-alpha.10</dd></dl>
           <dl class="version"><dt>DeepSeek Harness</dt><dd data-harness-version>0.1.0-rc.6</dd></dl>
           <dl class="version version-updated"><dt>验证更新时间</dt><dd data-updated>等待 GitHub 数据</dd></dl>
         </div>

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "dsh-desk"
-version = "0.1.0-alpha.9"
+version = "0.1.0-alpha.10"
 dependencies = [
  "base64 0.22.1",
  "flate2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dsh-desk"
-version = "0.1.0-alpha.9"
+version = "0.1.0-alpha.10"
 description = "A lightweight desktop shell for DeepSeek Harness"
 authors = ["DSH Desk contributors"]
 edition = "2024"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DSH Desk",
-  "version": "0.1.0-alpha.9",
+  "version": "0.1.0-alpha.10",
   "identifier": "ai.deepseek.harness.desk",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/plugin-catalog.json
+++ b/src/plugin-catalog.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "harnessVersion": "0.1.0-rc.6",
-  "desktopVersion": "0.1.0-alpha.9",
+  "desktopVersion": "0.1.0-alpha.10",
   "entries": [
     {
       "id": "web-search",


### PR DESCRIPTION
## Summary

- architecture-qualify macOS updater archives before provenance attestation and upload
- prevent arm64 and x64 updater artifacts from colliding during atomic publication
- add staging contract coverage and bump the immutable release version to 0.1.0-alpha.10

## Validation

- `pnpm check`
- `pnpm test:rust` (19 passed)
- `pnpm test:updater-contract`
- `pnpm test:plugin-catalog`
- `pnpm test:status-page`
- `actionlint`
- `git diff --check`