### PR TITLE
fix(release): enforce end-to-end publication verification

### DIFF
--- a/.github/workflows/publish-update-channel.yml
+++ b/.github/workflows/publish-update-channel.yml
@@ -23,6 +23,10 @@ jobs:
         with:
           ref: ${{ github.event.release.tag_name }}
           persist-credentials: false
+      - name: Install Linux desktop dependencies
+        run: >-
+          sudo apt-get update && sudo apt-get install -y
+          libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev patchelf libfuse2
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
           version: 11.21.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -344,7 +344,12 @@ jobs:
           mapfile -d '' assets < <(find release-staging -maxdepth 1 -type f \
             ! -name existing.json ! -name windows-release-metadata.json -print0)
           gh release upload "$GITHUB_REF_NAME" "${assets[@]}" --clobber
-          gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${GITHUB_REF_NAME}" > release-staging/release.json
+          release_id="$(gh release view "$GITHUB_REF_NAME" --json databaseId --jq .databaseId)"
+          prefix="https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}/"
+          gh api "repos/${GITHUB_REPOSITORY}/releases/${release_id}" |
+            jq --arg prefix "$prefix" \
+              '.assets |= map(.browser_download_url = ($prefix + (.name | @uri)))' \
+              > release-staging/release.json
           pnpm validate:update-manifest \
             release-staging/latest.json "$VERSION" "$GITHUB_REF_NAME" \
             release-staging/release.json

--- a/scripts/lib/release-artifacts.mjs
+++ b/scripts/lib/release-artifacts.mjs
@@ -67,10 +67,11 @@ export function stageReleaseArtifacts(platform, bundleRoot, outputDirectory, opt
         `${platform} release requires exactly one ${suffix} artifact, found ${matches.length}`,
       );
     }
-    const destinationName =
+    const destinationName = (
       platform === "macos" && suffix.startsWith(".app.tar.gz")
         ? `DSH Desk_${version}_${macArchitecture}${suffix}`
-        : basename(matches[0]);
+        : basename(matches[0])
+    ).replaceAll(" ", ".");
     const destination = join(destinationRoot, destinationName);
     if (existsSync(destination)) {
       throw new Error(`Refusing to overwrite staged release artifact: ${destination}`);

--- a/scripts/test-release-artifacts.mjs
+++ b/scripts/test-release-artifacts.mjs
@@ -63,7 +63,8 @@ try {
   });
   if (
     !stagedMac.some((file) => file.endsWith(`_${version}_aarch64.app.tar.gz`)) ||
-    !stagedMac.some((file) => file.endsWith(`_${version}_aarch64.app.tar.gz.sig`))
+    !stagedMac.some((file) => file.endsWith(`_${version}_aarch64.app.tar.gz.sig`)) ||
+    stagedMac.some((file) => basename(file).includes(" "))
   ) {
     throw new Error("macOS updater artifacts were not architecture-qualified before publishing");
   }

--- a/scripts/test-updater-contract.mjs
+++ b/scripts/test-updater-contract.mjs
@@ -75,6 +75,8 @@ for (const token of [
   "Verify Windows Authenticode state",
   "windows-release-metadata.json",
   "Windows Alpha signing notice",
+  'gh release view "$GITHUB_REF_NAME" --json databaseId',
+  ".browser_download_url = ($prefix + (.name | @uri))",
   "needs: preflight",
   "uploadUpdaterJson: false",
   "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02",
@@ -191,6 +193,13 @@ assert(
   !updatePreviewWorkflow.includes("uses: tauri-apps/tauri-action@v1") &&
     !updatePreviewWorkflow.includes("uses: softprops/action-gh-release@v2"),
   "Update preview publishing actions must be pinned to reviewed commits",
+);
+
+const updateChannelWorkflow = read(".github/workflows/publish-update-channel.yml");
+assert(
+  updateChannelWorkflow.includes("libwebkit2gtk-4.1-dev") &&
+    updateChannelWorkflow.includes("DSH_VERIFY_UPDATE_ARTIFACTS: '1'"),
+  "Published updater verification must install native Rust test dependencies",
 );
 
 console.log("Updater configuration, signing, release, and capability contracts passed.");

--- a/src-tauri/tests/updater_signing.rs
+++ b/src-tauri/tests/updater_signing.rs
@@ -6,6 +6,27 @@ use minisign_verify::{PublicKey, Signature};
 #[test]
 #[ignore = "requires release signing secrets and is run by pnpm check:updater-key"]
 fn configured_public_key_verifies_the_release_signing_key() {
+    assert_private_key_is_not_exposed();
+    let payload_path = env::var("DSH_UPDATER_TEST_PAYLOAD")
+        .expect("DSH_UPDATER_TEST_PAYLOAD is required for the release key gate");
+    let signature_path = env::var("DSH_UPDATER_TEST_SIGNATURE")
+        .expect("DSH_UPDATER_TEST_SIGNATURE must accompany the updater test payload");
+    let encoded_signature = fs::read_to_string(signature_path).expect("signature must be readable");
+    verify_payload(&payload_path, &encoded_signature);
+}
+
+#[test]
+#[ignore = "downloads and verifies published updater artifacts"]
+fn provided_update_artifact_has_valid_signature() {
+    assert_private_key_is_not_exposed();
+    let payload_path = env::var("DSH_UPDATER_ARTIFACT")
+        .expect("DSH_UPDATER_ARTIFACT is required for published artifact verification");
+    let encoded_signature = env::var("DSH_UPDATER_ARTIFACT_SIGNATURE")
+        .expect("DSH_UPDATER_ARTIFACT_SIGNATURE must accompany the published artifact");
+    verify_payload(&payload_path, &encoded_signature);
+}
+
+fn assert_private_key_is_not_exposed() {
     for name in [
         "TAURI_SIGNING_PRIVATE_KEY",
         "TAURI_SIGNING_PRIVATE_KEY_PATH",
@@ -16,11 +37,9 @@ fn configured_public_key_verifies_the_release_signing_key() {
             "{name} must not be exposed to Cargo tests"
         );
     }
-    let payload_path = env::var("DSH_UPDATER_TEST_PAYLOAD")
-        .expect("DSH_UPDATER_TEST_PAYLOAD is required for the release key gate");
-    let signature_path = env::var("DSH_UPDATER_TEST_SIGNATURE")
-        .expect("DSH_UPDATER_TEST_SIGNATURE must accompany the updater test payload");
+}
 
+fn verify_payload(payload_path: &str, encoded_signature: &str) {
     let config: serde_json::Value = serde_json::from_str(include_str!("../tauri.conf.json"))
         .expect("tauri.conf.json must be valid JSON");
     let encoded_public_key = config
@@ -34,7 +53,6 @@ fn configured_public_key_verifies_the_release_signing_key() {
         std::str::from_utf8(&public_key_text).expect("decoded updater public key must be UTF-8"),
     )
     .expect("decoded updater public key must be valid minisign data");
-    let encoded_signature = fs::read_to_string(signature_path).expect("signature must be readable");
     let signature_text = STANDARD
         .decode(encoded_signature.trim())
         .expect("updater signature must use valid base64");
@@ -42,7 +60,7 @@ fn configured_public_key_verifies_the_release_signing_key() {
         std::str::from_utf8(&signature_text).expect("decoded updater signature must be UTF-8"),
     )
     .expect("signature must be valid minisign data");
-    let payload = fs::read(payload_path).expect("signed updater test payload must be readable");
+    let payload = fs::read(payload_path).expect("signed updater payload must be readable");
 
     public_key
         .verify(&payload, &signature, false)


### PR DESCRIPTION
## Summary

- run the actual published-updater signature test instead of a nonexistent filtered name
- install native Linux dependencies before channel verification
- normalize staged asset names before upload
- resolve private draft releases by ID and validate their future public URLs

## Validation

- `pnpm check`
- `pnpm test:rust` (19 passed, 2 explicitly ignored release-only tests)
- `pnpm test:updater-contract`
- `actionlint`
- downloaded and cryptographically verified all five unique v0.1.0-alpha.10 updater artifacts (`1 passed` each)
- `git diff --check`