### PR TITLE
chore(release): prepare 0.1.0-alpha.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-desk",
   "private": true,
-  "version": "0.1.0-alpha.10",
+  "version": "0.1.0-alpha.11",
   "description": "Installable Tauri desktop distribution for DeepSeek Harness with a bundled runtime and daily compatibility checks.",
   "license": "MIT",
   "homepage": "https://github.com/majiayu000/dsh-desk/releases",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "dsh-desk"
-version = "0.1.0-alpha.10"
+version = "0.1.0-alpha.11"
 dependencies = [
  "base64 0.22.1",
  "flate2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dsh-desk"
-version = "0.1.0-alpha.10"
+version = "0.1.0-alpha.11"
 description = "A lightweight desktop shell for DeepSeek Harness"
 authors = ["DSH Desk contributors"]
 edition = "2024"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DSH Desk",
-  "version": "0.1.0-alpha.10",
+  "version": "0.1.0-alpha.11",
   "identifier": "ai.deepseek.harness.desk",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## 用户问题

PR #19 修复了正式 Release 和更新通道验证链路，但该修复尚未通过新的生产标签端到端验证。

Fixes #20

## 变更与边界

- [x] 没有 fork 官方业务 UI 或复制 Harness 状态
- [x] 没有向远端 Harness origin 增加 Tauri IPC/shell/文件系统权限
- [x] 没有记录凭据、提示词、路径或完整工具输出
- [x] 失败保持 fail closed，并提供恢复方式
- 将 package、Tauri、Cargo 和锁文件版本统一递增到 `0.1.0-alpha.11`
- 不包含 PR #9 或其他逻辑变更

## 验证

- `pnpm check`
- `pnpm test:rust`：19 passed，2 release-only tests ignored
- `pnpm test:updater-contract`
- `pnpm test:harness-contract`
- `pnpm test:plugin-template`
- `git diff --check`

## 兼容与发布

- DSH：0.1.0-rc.6
- Node：24（正式发布 runtime）
- 平台：macOS arm64/x64、Windows x64、Linux x64
- 签名/更新影响：触发 `v0.1.0-alpha.11` 后使用正式 Developer ID、公证、updater minisign 和原子 update-channel 流程；Windows Alpha 在无 Authenticode 凭据时明确发布为 unsigned。

## AI 辅助披露

本 PR 使用了 AI 辅助进行版本一致性检查、测试执行和发布验证。