### PR TITLE
fix(release): dispatch verified update channel

### DIFF
--- a/.github/workflows/publish-update-channel.yml
+++ b/.github/workflows/publish-update-channel.yml
@@ -3,6 +3,12 @@ name: Publish verified update channel
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Published v* release tag to verify and publish
+        required: true
+        type: string
 
 concurrency:
   group: release-update-channel
@@ -10,14 +16,14 @@ concurrency:
 
 jobs:
   validate:
-    if: startsWith(github.event.release.tag_name, 'v')
+    if: startsWith(github.event.release.tag_name || inputs.release_tag, 'v')
     runs-on: ubuntu-24.04
     outputs:
       channel-branch: ${{ steps.channel.outputs.branch }}
     permissions:
       contents: read
     env:
-      RELEASE_TAG: ${{ github.event.release.tag_name }}
+      RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -89,7 +95,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       CHANNEL_BRANCH: ${{ needs.validate.outputs.channel-branch }}
-      RELEASE_TAG: ${{ github.event.release.tag_name }}
+      RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:

--- a/.github/workflows/publish-update-channel.yml
+++ b/.github/workflows/publish-update-channel.yml
@@ -9,25 +9,32 @@ on:
         description: Published v* release tag to verify and publish
         required: true
         type: string
+  workflow_call:
+    inputs:
+      release_tag:
+        description: Published v* release tag to verify and publish
+        required: true
+        type: string
 
 concurrency:
   group: release-update-channel
+  queue: max
   cancel-in-progress: false
 
 jobs:
   validate:
-    if: startsWith(github.event.release.tag_name || inputs.release_tag, 'v')
+    if: inputs.release_tag != '' || startsWith(github.event.release.tag_name, 'v')
     runs-on: ubuntu-24.04
     outputs:
       channel-branch: ${{ steps.channel.outputs.branch }}
     permissions:
       contents: read
     env:
-      RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
+      RELEASE_TAG: ${{ inputs.release_tag || github.event.release.tag_name }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ inputs.release_tag || github.event.release.tag_name }}
           persist-credentials: false
       - name: Install Linux desktop dependencies
         run: >-
@@ -95,7 +102,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       CHANNEL_BRANCH: ${{ needs.validate.outputs.channel-branch }}
-      RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
+      RELEASE_TAG: ${{ inputs.release_tag || github.event.release.tag_name }}
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:

--- a/.github/workflows/publish-update-channel.yml
+++ b/.github/workflows/publish-update-channel.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ inputs.release_tag || github.event.release.tag_name }}
+          ref: refs/tags/${{ inputs.release_tag || github.event.release.tag_name }}
           persist-credentials: false
       - name: Install Linux desktop dependencies
         run: >-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -279,7 +279,7 @@ jobs:
       name: production
       url: https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}
     permissions:
-      actions: read
+      actions: write
       contents: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -364,3 +364,10 @@ jobs:
           pnpm validate:update-manifest \
             release-staging/latest.json "$VERSION" "$GITHUB_REF_NAME" \
             release-staging/release.json
+      - name: Dispatch verified update channel
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          gh workflow run publish-update-channel.yml
+          --ref "$GITHUB_REF_NAME"
+          -f release_tag="$GITHUB_REF_NAME"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -279,7 +279,7 @@ jobs:
       name: production
       url: https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}
     permissions:
-      actions: write
+      actions: read
       contents: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -364,10 +364,12 @@ jobs:
           pnpm validate:update-manifest \
             release-staging/latest.json "$VERSION" "$GITHUB_REF_NAME" \
             release-staging/release.json
-      - name: Dispatch verified update channel
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: >-
-          gh workflow run publish-update-channel.yml
-          --ref "$GITHUB_REF_NAME"
-          -f release_tag="$GITHUB_REF_NAME"
+
+  publish-update-channel:
+    name: Publish verified update channel
+    needs: publish
+    permissions:
+      contents: write
+    uses: ./.github/workflows/publish-update-channel.yml
+    with:
+      release_tag: ${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -279,7 +279,6 @@ jobs:
       name: production
       url: https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}
     permissions:
-      actions: read
       contents: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/scripts/test-updater-contract.mjs
+++ b/scripts/test-updater-contract.mjs
@@ -86,10 +86,9 @@ for (const token of [
   "pnpm release:artifacts manifest",
   "DSH_ALLOW_DRAFT_RELEASE: '1'",
   'gh release edit "$GITHUB_REF_NAME" --draft=false',
-  "actions: write",
-  "gh workflow run publish-update-channel.yml",
-  '--ref "$GITHUB_REF_NAME"',
-  '-f release_tag="$GITHUB_REF_NAME"',
+  "publish-update-channel:",
+  "uses: ./.github/workflows/publish-update-channel.yml",
+  "release_tag: ${{ github.ref_name }}",
 ]) {
   assert(workflow.includes(token), `Release workflow is missing ${token}`);
 }
@@ -204,9 +203,16 @@ assert(
   updateChannelWorkflow.includes("libwebkit2gtk-4.1-dev") &&
     updateChannelWorkflow.includes("DSH_VERIFY_UPDATE_ARTIFACTS: '1'") &&
     updateChannelWorkflow.includes("workflow_dispatch:") &&
-    updateChannelWorkflow.includes("release_tag:") &&
+    updateChannelWorkflow.includes("workflow_call:") &&
+    updateChannelWorkflow.includes("queue: max") &&
     updateChannelWorkflow.includes(
-      "RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}",
+      "if: inputs.release_tag != '' || startsWith(github.event.release.tag_name, 'v')",
+    ) &&
+    updateChannelWorkflow.includes(
+      "ref: ${{ inputs.release_tag || github.event.release.tag_name }}",
+    ) &&
+    updateChannelWorkflow.includes(
+      "RELEASE_TAG: ${{ inputs.release_tag || github.event.release.tag_name }}",
     ),
   "Published updater verification must install native Rust test dependencies",
 );

--- a/scripts/test-updater-contract.mjs
+++ b/scripts/test-updater-contract.mjs
@@ -209,7 +209,7 @@ assert(
       "if: inputs.release_tag != '' || startsWith(github.event.release.tag_name, 'v')",
     ) &&
     updateChannelWorkflow.includes(
-      "ref: ${{ inputs.release_tag || github.event.release.tag_name }}",
+      "ref: refs/tags/${{ inputs.release_tag || github.event.release.tag_name }}",
     ) &&
     updateChannelWorkflow.includes(
       "RELEASE_TAG: ${{ inputs.release_tag || github.event.release.tag_name }}",

--- a/scripts/test-updater-contract.mjs
+++ b/scripts/test-updater-contract.mjs
@@ -86,6 +86,10 @@ for (const token of [
   "pnpm release:artifacts manifest",
   "DSH_ALLOW_DRAFT_RELEASE: '1'",
   'gh release edit "$GITHUB_REF_NAME" --draft=false',
+  "actions: write",
+  "gh workflow run publish-update-channel.yml",
+  '--ref "$GITHUB_REF_NAME"',
+  '-f release_tag="$GITHUB_REF_NAME"',
 ]) {
   assert(workflow.includes(token), `Release workflow is missing ${token}`);
 }
@@ -198,7 +202,12 @@ assert(
 const updateChannelWorkflow = read(".github/workflows/publish-update-channel.yml");
 assert(
   updateChannelWorkflow.includes("libwebkit2gtk-4.1-dev") &&
-    updateChannelWorkflow.includes("DSH_VERIFY_UPDATE_ARTIFACTS: '1'"),
+    updateChannelWorkflow.includes("DSH_VERIFY_UPDATE_ARTIFACTS: '1'") &&
+    updateChannelWorkflow.includes("workflow_dispatch:") &&
+    updateChannelWorkflow.includes("release_tag:") &&
+    updateChannelWorkflow.includes(
+      "RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}",
+    ),
   "Published updater verification must install native Rust test dependencies",
 );
 


### PR DESCRIPTION
## 用户问题

正式 Release 由 workflow 的 `GITHUB_TOKEN` 发布时，生成的 `release.published` 事件不会递归触发新的 workflow，导致已验证 Release 无法自动进入客户端 update channel。

Fixes #22

## 变更与边界

- [x] 没有 fork 官方业务 UI 或复制 Harness 状态
- [x] 没有向远端 Harness origin 增加 Tauri IPC/shell/文件系统权限
- [x] 没有记录凭据、提示词、路径或完整工具输出
- [x] 失败保持 fail closed，并提供恢复方式
- update-channel workflow 增加必填 `release_tag` 的 `workflow_dispatch`
- 正式 Release 完成公开和最终 manifest 验证后显式 dispatch
- 保留 `release.published` 入口，兼容人工发布
- 不引入长期 PAT 或额外 secrets

## 验证

- `pnpm test:updater-contract`
- `pnpm check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest`
- `git diff --check`

## 兼容与发布

- DSH：无变化
- Node：无变化
- 平台：GitHub Actions release/update channel
- 签名/更新影响：不改变签名算法或密钥；只保证已公开且校验通过的 Release 显式进入既有签名、资产和单调版本验证流程。

## AI 辅助披露

本 PR 使用了 AI 辅助进行根因定位、最小工作流修改、契约测试和验证。