### PR TITLE
chore: align leftover Actions pins and bump semver

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,7 +29,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: actions/configure-pages@v6
       - uses: actions/upload-pages-artifact@v5
         with:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -37,7 +37,7 @@ jobs:
             runner: ubuntu-22.04
             tauri_args: -vv --bundles appimage,deb
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install Linux desktop dependencies
         if: runner.os == 'Linux'
         run: >-
@@ -46,7 +46,7 @@ jobs:
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
           version: 11.21.0
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: pnpm
@@ -78,7 +78,7 @@ jobs:
       - name: Write SHA-256 checksums
         run: pnpm release:checksums
       - name: Upload preview installer
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dsh-desk-${{ matrix.platform }}-${{ github.sha }}
           if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -262,7 +262,7 @@ jobs:
         with:
           subject-path: release-staging/${{ matrix.artifact }}/*
       - name: Upload immutable platform artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-${{ matrix.artifact }}-${{ github.sha }}
           path: release-staging/${{ matrix.artifact }}/*

--- a/.github/workflows/update-preview.yml
+++ b/.github/workflows/update-preview.yml
@@ -38,7 +38,7 @@ jobs:
             runner: ubuntu-22.04
             tauri_args: -vv --bundles appimage,deb
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install Linux desktop dependencies
         if: runner.os == 'Linux'
         run: >-
@@ -47,7 +47,7 @@ jobs:
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
           version: 11.21.0
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: pnpm
@@ -108,11 +108,11 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
           version: 11.21.0
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: pnpm
@@ -131,7 +131,7 @@ jobs:
             update-channel/latest.json "$version" "preview-v${version}" \
             update-channel/release.json
       - name: Atomically replace preview channel metadata
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           tag_name: preview-channel
           name: DSH Desk preview update channel

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@tauri-apps/cli": "2.11.4",
-    "semver": "7.7.2",
+    "semver": "7.8.5",
     "typescript": "7.0.2",
     "vite": "8.2.1"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,8 +26,8 @@ importers:
         specifier: 2.11.4
         version: 2.11.4
       semver:
-        specifier: 7.7.2
-        version: 7.7.2
+        specifier: 7.8.5
+        version: 7.8.5
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -3826,11 +3826,6 @@ packages:
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
-
-  semver@7.7.2:
-    resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
-    engines: {node: '>=10'}
-    hasBin: true
 
   semver@7.8.5:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
@@ -8514,8 +8509,6 @@ snapshots:
   scheduler@0.23.2:
     dependencies:
       loose-envify: 1.4.0
-
-  semver@7.7.2: {}
 
   semver@7.8.5: {}
 

--- a/scripts/test-updater-contract.mjs
+++ b/scripts/test-updater-contract.mjs
@@ -100,7 +100,7 @@ for (const token of [
   ".browser_download_url = ($prefix + (.name | @uri))",
   "needs: preflight",
   "uploadUpdaterJson: false",
-  "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02",
+  "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
   "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c",
   "merge-multiple: true",
   "environment:\n      name: production",
@@ -130,6 +130,7 @@ assert(
 );
 assert(
   !workflow.includes("actions/upload-artifact@v4") &&
+    !workflow.includes("actions/upload-artifact@v7") &&
     !workflow.includes("actions/download-artifact@v8"),
   "Release artifact actions must be pinned to reviewed commits",
 );
@@ -175,7 +176,8 @@ assert(
   "Unsigned preview builds must not consume repository secrets",
 );
 assert(
-  !previewWorkflow.includes("actions/upload-artifact@v4"),
+  !previewWorkflow.includes("actions/upload-artifact@v4") &&
+    !previewWorkflow.includes("actions/upload-artifact@v7"),
   "Preview artifact upload action must be pinned to a reviewed commit",
 );
 
@@ -205,6 +207,7 @@ for (const token of [
   "node scripts/validate-update-manifest.mjs",
   "tag_name: preview-channel",
   "overwrite_files: true",
+  "softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228",
 ]) {
   assert(updatePreviewWorkflow.includes(token), `Update preview workflow is missing ${token}`);
 }
@@ -215,7 +218,8 @@ assert(
 );
 assert(
   !updatePreviewWorkflow.includes("uses: tauri-apps/tauri-action@v1") &&
-    !updatePreviewWorkflow.includes("uses: softprops/action-gh-release@v2"),
+    !updatePreviewWorkflow.includes("uses: softprops/action-gh-release@v2") &&
+    !updatePreviewWorkflow.includes("uses: softprops/action-gh-release@v3"),
   "Update preview publishing actions must be pinned to reviewed commits",
 );
 


### PR DESCRIPTION
## 用户问题

CI 已经用 checkout/setup-node v7，但 preview、update-preview、release 仍混着 v4/v6 pin。Dependabot 单独升 upload-artifact 会撞契约测试。

## 变更与边界

- 把剩余 workflow 钉到与正式通道相同的 reviewed SHA
- 契约测试同步新 SHA，并禁止未钉死的 `@v4`/`@v7`/`@v2`/`@v3` tag
- 开发依赖 `semver` 7.7.2 → 7.8.5
- 不升 `src-tauri` 的 `base64`：`tauri-plugin-updater` 仍要求 `^0.22`

## 验证

- `node scripts/test-updater-contract.mjs`

合并后关闭 #27 #29 #30 #31 #32。关闭 #28。