### PR TITLE
chore(release): prepare 0.1.0-alpha.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-desk",
   "private": true,
-  "version": "0.1.0-alpha.11",
+  "version": "0.1.0-alpha.12",
   "description": "Installable Tauri desktop distribution for DeepSeek Harness with a bundled runtime and daily compatibility checks.",
   "license": "MIT",
   "homepage": "https://github.com/majiayu000/dsh-desk/releases",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "dsh-desk"
-version = "0.1.0-alpha.11"
+version = "0.1.0-alpha.12"
 dependencies = [
  "base64 0.22.1",
  "flate2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dsh-desk"
-version = "0.1.0-alpha.11"
+version = "0.1.0-alpha.12"
 description = "A lightweight desktop shell for DeepSeek Harness"
 authors = ["DSH Desk contributors"]
 edition = "2024"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DSH Desk",
-  "version": "0.1.0-alpha.11",
+  "version": "0.1.0-alpha.12",
   "identifier": "ai.deepseek.harness.desk",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/plugin-catalog.json
+++ b/src/plugin-catalog.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "harnessVersion": "0.1.0-rc.6",
-  "desktopVersion": "0.1.0-alpha.11",
+  "desktopVersion": "0.1.0-alpha.12",
   "entries": [
     {
       "id": "web-search",


### PR DESCRIPTION
## 用户问题

`v0.1.0-alpha.11` 之后的更新中心、fail-closed 和社区目录还没进正式包。需要一个新的 `v*` 标签才能走生产 Release。

## 变更与边界

- [x] 没有 fork 官方业务 UI 或复制 Harness 状态
- [x] 没有向远端 Harness origin 增加 Tauri IPC/shell/文件系统权限
- [x] 没有记录凭据、提示词、路径或完整工具输出
- [x] 失败保持 fail closed，并提供恢复方式

只把桌面版本同步到 `0.1.0-alpha.12`。Harness 仍是 `@deepseek-ai/dsh@0.1.0-rc.6`（npm `latest`/`next` 均为该版本）。

## 验证

- `pnpm test:updater-contract`
- `pnpm test:plugin-catalog`
- `node scripts/check-upstream-version.mjs` → `{"pinned":"0.1.0-rc.6","latest":"0.1.0-rc.6","drift":false}`

## 兼容与发布

- DSH：`0.1.0-rc.6`（未改 pin）
- Node：未改
- 平台：版本号四处对齐，含插件目录
- 签名/更新影响：合并后打全新 `v0.1.0-alpha.12`，不移动旧标签

Closes #34 after the tagged Release and channel publish succeed.