### PR TITLE
docs: record v0.1.0-alpha.12 end-to-end release evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ DeepSeek Harness already provides the agent runtime, web UI, sessions, tools, ap
 
 | Platform | Public status | Signing status |
 |---|---|---|
-| macOS Apple Silicon & Intel | `v0.1.0-alpha.11` DMG (both architectures) | Developer ID signed, notarized, stapled |
-| Windows x64 | `v0.1.0-alpha.11` NSIS installer | Unsigned alpha (SmartScreen notice); updater payloads independently signed |
-| Linux x64 | `v0.1.0-alpha.11` AppImage & deb | Updater signatures included |
+| macOS Apple Silicon & Intel | `v0.1.0-alpha.12` DMG (both architectures) | Developer ID signed, notarized, stapled |
+| Windows x64 | `v0.1.0-alpha.12` NSIS installer | Unsigned alpha (SmartScreen notice); updater payloads independently signed |
+| Linux x64 | `v0.1.0-alpha.12` AppImage & deb | Updater signatures included |
 
-The [`v0.1.0-alpha.11` release run](https://github.com/majiayu000/dsh-desk/actions/runs/31937135348) completed all six jobs — preflight, the four platform bundles (including macOS signing, notarization, and verify-from-DMG), and the final `Publish atomic release` step — and published 18 installer, updater, signature, SHA-256, and `latest.json` assets. The update channel was then republished atomically with manifest and full payload verification ([channel run](https://github.com/majiayu000/dsh-desk/actions/runs/31941091678), acceptance evidence in [issue #20](https://github.com/majiayu000/dsh-desk/issues/20)). The previous `v0.1.0-alpha.10` run had passed all four bundle jobs but failed its publish step; the repaired pipeline is now verified end to end. Windows alpha releases may be published without Authenticode and say so in their Release Notes. See the live [compatibility radar](https://majiayu000.github.io/dsh-desk/), [compatibility evidence](docs/compatibility.md), and individual [Actions runs](https://github.com/majiayu000/dsh-desk/actions) for the latest facts.
+The [`v0.1.0-alpha.12` release run](https://github.com/majiayu000/dsh-desk/actions/runs/31999103490) completed preflight, the four platform bundles (including macOS signing, notarization, and verify-from-DMG), `Publish atomic release`, and the nested update-channel validate/publish jobs. It published 18 installer, updater, signature, SHA-256, and `latest.json` assets; the alpha channel was then updated atomically to `0.1.0-alpha.12`. Acceptance evidence is in [issue #34](https://github.com/majiayu000/dsh-desk/issues/34). Windows alpha releases may be published without Authenticode and say so in their Release Notes. See the live [compatibility radar](https://majiayu000.github.io/dsh-desk/), [compatibility evidence](docs/compatibility.md), and individual [Actions runs](https://github.com/majiayu000/dsh-desk/actions) for the latest facts.
 
 ## What is different
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -54,15 +54,15 @@
 
 | 平台 | 当前状态 | 签名状态 |
 |---|---|---|
-| macOS Apple Silicon 与 Intel | `v0.1.0-alpha.11` DMG（双架构） | Developer ID 签名、公证并 staple |
-| Windows x64 | `v0.1.0-alpha.11` NSIS 安装包 | Alpha 未签名（Release Notes 已说明 SmartScreen）；updater 工件独立签名 |
-| Linux x64 | `v0.1.0-alpha.11` AppImage / deb | 含 updater 签名 |
+| macOS Apple Silicon 与 Intel | `v0.1.0-alpha.12` DMG（双架构） | Developer ID 签名、公证并 staple |
+| Windows x64 | `v0.1.0-alpha.12` NSIS 安装包 | Alpha 未签名（Release Notes 已说明 SmartScreen）；updater 工件独立签名 |
+| Linux x64 | `v0.1.0-alpha.12` AppImage / deb | 含 updater 签名 |
 
-[`v0.1.0-alpha.11` 发布运行](https://github.com/majiayu000/dsh-desk/actions/runs/31937135348)的六个 job 全部通过（含 macOS 签名、公证、DMG 内容验证与最后的 `Publish atomic release` 步骤），共发布 18 个安装包、updater、签名、SHA-256 与 `latest.json` 资产；更新通道随后原子重发布，并完成清单与全部唯一 updater 资产的验签（[通道运行](https://github.com/majiayu000/dsh-desk/actions/runs/31941091678)，验收证据见 [Issue #20](https://github.com/majiayu000/dsh-desk/issues/20)）。上一个 `v0.1.0-alpha.10` 标签四个打包 job 通过但发布步骤失败，修复后的链路已由 alpha.11 端到端验证。Release 工作流缺少生产证书时会直接失败，不会把未签名资产伪装成正式版。最新事实以[兼容矩阵](docs/compatibility.md)和具体 [Actions 运行记录](https://github.com/majiayu000/dsh-desk/actions)为准。
+[`v0.1.0-alpha.12` 发布运行](https://github.com/majiayu000/dsh-desk/actions/runs/31999103490)完成了 preflight、四个平台打包（含 macOS 签名、公证、DMG 内容验证）、`Publish atomic release`，以及嵌套的更新通道 validate/publish。共发布 18 个安装包、updater、签名、SHA-256 与 `latest.json` 资产；alpha 通道随后原子更新到 `0.1.0-alpha.12`。验收证据见 [Issue #34](https://github.com/majiayu000/dsh-desk/issues/34)。Release 工作流缺少生产证书时会直接失败，不会把未签名资产伪装成正式版。最新事实以[兼容矩阵](docs/compatibility.md)和具体 [Actions 运行记录](https://github.com/majiayu000/dsh-desk/actions)为准。
 
 ## 快速开始
 
-1. 从 [Releases](https://github.com/majiayu000/dsh-desk/releases) 下载对应平台安装包（当前推荐 `v0.1.0-alpha.11`）。
+1. 从 [Releases](https://github.com/majiayu000/dsh-desk/releases) 下载对应平台安装包（当前推荐 `v0.1.0-alpha.12`）。
 2. 安装并启动 DSH Desk；应用自动验证并启动内置 Harness。
 3. 官方 Harness 首次启动弹窗会要求配置可用模型；填写 API Key 并点击“保存并继续”，即可发送第一条任务。
 
@@ -72,7 +72,7 @@ DSH Desk 不读取或保存模型 API Key；首次启动弹窗通过 Harness 官
 
 ## 当前限制
 
-- 公开下载已覆盖 macOS 双架构、Windows 与 Linux（`v0.1.0-alpha.11`），仍处 Alpha；发布链路已由 `v0.1.0-alpha.11` 端到端验证（[Issue #20](https://github.com/majiayu000/dsh-desk/issues/20)）；
+- 公开下载已覆盖 macOS 双架构、Windows 与 Linux（`v0.1.0-alpha.12`），仍处 Alpha；发布链路已由 `v0.1.0-alpha.12` 端到端验证（[Issue #34](https://github.com/majiayu000/dsh-desk/issues/34)）；
 - Windows 安装包未做 Authenticode 签名，SmartScreen 提示属预期，安装前请核对 SHA-256；
 - 离线包包含固定 Node.js 与完整 Harness runtime，当前 DMG 约 215 MB；
 - DeepSeek Harness 仍处于快速变化阶段，每日兼容测试只能发现漂移，不能保证未来永不发生破坏性变更；

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -9,23 +9,22 @@ DSH Desk 将桌面壳、Node、DeepSeek Harness 和 Web UI 作为一个固定版
 
 | DSH Desk | DeepSeek Harness | Node | macOS arm64 | Windows x64 | Linux x64 |
 |---|---|---|---|---|---|
-| `0.1.0-alpha.11` | `0.1.0-rc.6` | `24.x` | 已验证 | 已验证 | 已验证 |
+| `0.1.0-alpha.12` | `0.1.0-rc.6` | `24.x` | 已验证 | 已验证 | 已验证 |
 
 这里的“已验证”指该固定组合通过三平台 CI 契约：TypeScript/Rust 构建、固定 DSH 版本、严格
-loopback 健康检查、离线 runtime 与插件 parity。最近一次公开运行（2026-08-16，含 PR #23）：
-[GitHub Actions #31941075574](https://github.com/majiayu000/dsh-desk/actions/runs/31941075574)。
+loopback 健康检查、离线 runtime 与插件 parity。最近一次公开运行（2026-08-17，版本准备 PR #35）：
+[GitHub Actions #31998521392](https://github.com/majiayu000/dsh-desk/actions/runs/31998521392)。
 每日兼容检查（含 npm `latest` 候选）最近一次成功运行：
-[GitHub Actions #31923751715](https://github.com/majiayu000/dsh-desk/actions/runs/31923751715)。
+[GitHub Actions #31990498493](https://github.com/majiayu000/dsh-desk/actions/runs/31990498493)。
 
-`v0.1.0-alpha.11` 已完成端到端发布验证：Release 运行的六个 job（preflight、macOS arm64/x64、
-Windows x64、Linux x64、`Publish atomic release`）全部成功，共发布 18 个安装包、updater、签名、
-SHA-256 与 `latest.json` 资产；随后更新通道工作流原子更新 manifest，并对全部唯一 updater 资产
-完成下载与验签：
-[Release v0.1.0-alpha.11](https://github.com/majiayu000/dsh-desk/releases/tag/v0.1.0-alpha.11) ·
-[Release Actions #31937135348](https://github.com/majiayu000/dsh-desk/actions/runs/31937135348) ·
-[Channel Actions #31941091678](https://github.com/majiayu000/dsh-desk/actions/runs/31941091678)。
+`v0.1.0-alpha.12` 已完成端到端发布验证：preflight、macOS arm64/x64、Windows x64、Linux x64、
+`Publish atomic release` 以及嵌套的 update-channel validate/publish 全部成功，共发布 18 个安装包、
+updater、签名、SHA-256 与 `latest.json` 资产；`update-channel-alpha` 原子更新到
+`0.1.0-alpha.12`（提交 `69d55f51c94765c8fea7b0c5ada4c852211a8cbc`），通道含 9 个平台键：
+[Release v0.1.0-alpha.12](https://github.com/majiayu000/dsh-desk/releases/tag/v0.1.0-alpha.12) ·
+[Release Actions #31999103490](https://github.com/majiayu000/dsh-desk/actions/runs/31999103490)。
 macOS 含 Developer ID 签名、notarization 与 DMG 内容验证；Windows 为无签名的 Alpha 安装包。
-验收清单见 [Issue #20](https://github.com/majiayu000/dsh-desk/issues/20)。
+验收清单见 [Issue #34](https://github.com/majiayu000/dsh-desk/issues/34)。
 
 ### 历史证据
 

--- a/site/index.html
+++ b/site/index.html
@@ -168,7 +168,7 @@
         </div>
 
         <div class="versions" aria-label="Pinned versions">
-          <dl class="version"><dt>DSH Desk</dt><dd data-desktop-version>0.1.0-alpha.11</dd></dl>
+          <dl class="version"><dt>DSH Desk</dt><dd data-desktop-version>0.1.0-alpha.12</dd></dl>
           <dl class="version"><dt>DeepSeek Harness</dt><dd data-harness-version>0.1.0-rc.6</dd></dl>
           <dl class="version version-updated"><dt>Evidence updated</dt><dd data-updated>waiting for GitHub</dd></dl>
         </div>

--- a/site/zh-CN/index.html
+++ b/site/zh-CN/index.html
@@ -168,7 +168,7 @@
         </div>
 
         <div class="versions" aria-label="固定版本">
-          <dl class="version"><dt>DSH Desk</dt><dd data-desktop-version>0.1.0-alpha.11</dd></dl>
+          <dl class="version"><dt>DSH Desk</dt><dd data-desktop-version>0.1.0-alpha.12</dd></dl>
           <dl class="version"><dt>DeepSeek Harness</dt><dd data-harness-version>0.1.0-rc.6</dd></dl>
           <dl class="version version-updated"><dt>验证更新时间</dt><dd data-updated>等待 GitHub 数据</dd></dl>
         </div>


### PR DESCRIPTION
## 用户问题

`v0.1.0-alpha.12` 已公开发布，README 和兼容矩阵仍推荐 alpha.11。

## 变更与边界

- [x] 没有 fork 官方业务 UI 或复制 Harness 状态
- [x] 没有向远端 Harness origin 增加 Tauri IPC/shell/文件系统权限
- [x] 没有记录凭据、提示词、路径或完整工具输出
- [x] 失败保持 fail closed，并提供恢复方式

只更新公开可用性文案和站点回退版本号。

## 验证

- `pnpm test:status-page`
- `pnpm test:doc-links`

## 兼容与发布

- DSH：`0.1.0-rc.6`
- 证据：[Release](https://github.com/majiayu000/dsh-desk/releases/tag/v0.1.0-alpha.12) · [Actions #31999103490](https://github.com/majiayu000/dsh-desk/actions/runs/31999103490) · [Issue #34](https://github.com/majiayu000/dsh-desk/issues/34)