### PR TITLE
fix: restore cross-platform About menu

### DIFF
--- a/scripts/test-desktop-menu-contract.mjs
+++ b/scripts/test-desktop-menu-contract.mjs
@@ -5,6 +5,29 @@ const root = resolve(import.meta.dirname, '..')
 const read = createContractReader(root)
 const desktopSource = read('src-tauri/src/lib.rs')
 
+assert(
+  desktopSource.includes('.about(Some(about_metadata))'),
+  'the About menu must receive metadata so Windows and Linux open a native dialog',
+)
+assert(
+  !desktopSource.includes('.about(None)'),
+  'the About menu must not silently no-op on Windows or Linux',
+)
+for (const field of ['name', 'version', 'authors', 'comments', 'license', 'website']) {
+  assert(
+    desktopSource.includes(`.${field}(Some(`),
+    `the native About dialog must include ${field} metadata`,
+  )
+}
+assert(
+  desktopSource.includes('show_menu_action_error(app, "打开插件管理窗口", error)'),
+  'plugin management menu failures must be shown to the user',
+)
+assert(
+  desktopSource.includes('show_menu_action_error(app, "打开软件更新窗口", error)'),
+  'software update menu failures must be shown to the user',
+)
+
 const editMenu = desktopSource.match(
   /#\[cfg\(target_os = "macos"\)\]\s*\{([\s\S]*?)\}\s*#\[cfg\(not\(target_os = "macos"\)\)\]/u,
 )?.[1]
@@ -29,4 +52,4 @@ assert(
   'the native Edit submenu must be attached to the application menu',
 )
 
-console.log('macOS native Edit menu contract passed.')
+console.log('Desktop menu contracts passed.')

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -18,11 +18,37 @@ use runtime_supervisor::{RuntimeHandle, RuntimeStatus, diagnostic_dir, spawn_wor
 use security_policy::window_can_invoke;
 use tauri::{
     Manager,
-    menu::{MenuBuilder, SubmenuBuilder},
+    menu::{AboutMetadata, AboutMetadataBuilder, MenuBuilder, SubmenuBuilder},
 };
+use tauri_plugin_dialog::{DialogExt, MessageDialogKind};
+
+const APPLICATION_NAME: &str = "DSH Desk";
+const APPLICATION_WEBSITE: &str = "https://github.com/majiayu000/dsh-desk";
 
 #[cfg(target_os = "macos")]
 const EDIT_MENU_ID: &str = "edit-menu";
+
+fn desktop_about_metadata(version: &str) -> AboutMetadata<'static> {
+    AboutMetadataBuilder::new()
+        .name(Some(APPLICATION_NAME))
+        .version(Some(version))
+        .authors(Some(vec!["DSH Desk contributors".to_string()]))
+        .comments(Some("A lightweight desktop shell for DeepSeek Harness"))
+        .license(Some("MIT"))
+        .website(Some(APPLICATION_WEBSITE))
+        .website_label(Some("DSH Desk on GitHub"))
+        .build()
+}
+
+fn show_menu_action_error(app: &tauri::AppHandle, action: &str, error: impl std::fmt::Display) {
+    let message = format!("{action}失败：{error}");
+    eprintln!("{message}");
+    app.dialog()
+        .message(message)
+        .title(APPLICATION_NAME)
+        .kind(MessageDialogKind::Error)
+        .show(|_| {});
+}
 
 fn require_command_window(window: &tauri::WebviewWindow, command: &str) -> Result<(), String> {
     if window_can_invoke(window.label(), command) {
@@ -179,8 +205,9 @@ pub fn run() {
             }
         }))
         .menu(|app| {
-            let application = SubmenuBuilder::with_id(app, "application-menu", "DSH Desk")
-                .about(None)
+            let about_metadata = desktop_about_metadata(&app.package_info().version.to_string());
+            let application = SubmenuBuilder::with_id(app, "application-menu", APPLICATION_NAME)
+                .about(Some(about_metadata))
                 .separator()
                 .text("open-plugins", "插件管理…")
                 .text("software-update", "软件更新…")
@@ -205,11 +232,14 @@ pub fn run() {
         })
         .on_menu_event(|app, event| {
             if event.id() == "open-plugins" {
-                let _ = window_manager::open_plugin_window(app);
-            } else if event.id() == "software-update"
-                && window_manager::open_update_window(app).is_ok()
-            {
-                updater::request_check_if_idle(app.clone());
+                if let Err(error) = window_manager::open_plugin_window(app) {
+                    show_menu_action_error(app, "打开插件管理窗口", error);
+                }
+            } else if event.id() == "software-update" {
+                match window_manager::open_update_window(app) {
+                    Ok(()) => updater::request_check_if_idle(app.clone()),
+                    Err(error) => show_menu_action_error(app, "打开软件更新窗口", error),
+                }
             }
         })
         .manage(runtime.clone())
@@ -263,4 +293,31 @@ pub fn run() {
         }
         _ => {}
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{APPLICATION_NAME, APPLICATION_WEBSITE, desktop_about_metadata};
+
+    #[test]
+    fn about_metadata_contains_cross_platform_dialog_fields() {
+        let metadata = desktop_about_metadata("0.1.0-test.1");
+
+        assert_eq!(metadata.name.as_deref(), Some(APPLICATION_NAME));
+        assert_eq!(metadata.version.as_deref(), Some("0.1.0-test.1"));
+        assert_eq!(
+            metadata.authors.as_deref(),
+            Some(["DSH Desk contributors".to_string()].as_slice())
+        );
+        assert_eq!(
+            metadata.comments.as_deref(),
+            Some("A lightweight desktop shell for DeepSeek Harness")
+        );
+        assert_eq!(metadata.license.as_deref(), Some("MIT"));
+        assert_eq!(metadata.website.as_deref(), Some(APPLICATION_WEBSITE));
+        assert_eq!(
+            metadata.website_label.as_deref(),
+            Some("DSH Desk on GitHub")
+        );
+    }
 }


### PR DESCRIPTION
## 用户问题

Windows 11 上点击 DSH Desk → About 没有任何响应，导致用户无法从标准桌面菜单查看当前版本。

Fixes #40

## 根因与同类检查

- Tauri 的预定义 About 项传入了 `.about(None)`。当前 Windows 和 Linux 菜单后端都只在收到元数据时创建原生 About 对话框，因此点击会直接无操作。
- “插件管理…”和“软件更新…”菜单创建窗口失败时也会吞掉错误，呈现为相同的点击无响应。
- Linux 不支持预定义 Quit，平台会过滤该菜单项而不是显示后无响应；本 PR 不改变退出语义。

## 变更与边界

- 为 About 提供应用名、运行时版本、作者、简介、MIT 许可证和项目网址。
- 插件管理/软件更新窗口失败时显示原生错误对话框，并同步写入 stderr。
- 扩展现有桌面菜单 contract，禁止重新引入 `.about(None)` 或静默菜单错误。
- 增加 Rust 单元测试，验证 About 元数据包含跨平台必需字段。
- 不改变 updater、runtime 关闭流程、能力权限或发布签名配置。

## 验证

- `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --all-features -- -D warnings`
- `pnpm check`
- `pnpm test:rust`：51 passed，2 个发布签名测试按设计 ignored

## 发布

本 PR 合并并通过三平台 CI 后，另行准备 `v0.1.0-alpha.13` 版本提交并触发标签发布。