### PR TITLE
chore(release): prepare 0.1.0-alpha.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-desk",
   "private": true,
-  "version": "0.1.0-alpha.12",
+  "version": "0.1.0-alpha.13",
   "description": "Installable Tauri desktop distribution for DeepSeek Harness with a bundled runtime and daily compatibility checks.",
   "license": "MIT",
   "homepage": "https://github.com/majiayu000/dsh-desk/releases",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "dsh-desk"
-version = "0.1.0-alpha.12"
+version = "0.1.0-alpha.13"
 dependencies = [
  "base64 0.22.1",
  "flate2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dsh-desk"
-version = "0.1.0-alpha.12"
+version = "0.1.0-alpha.13"
 description = "A lightweight desktop shell for DeepSeek Harness"
 authors = ["DSH Desk contributors"]
 edition = "2024"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DSH Desk",
-  "version": "0.1.0-alpha.12",
+  "version": "0.1.0-alpha.13",
   "identifier": "ai.deepseek.harness.desk",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/plugin-catalog.json
+++ b/src/plugin-catalog.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "harnessVersion": "0.1.0-rc.6",
-  "desktopVersion": "0.1.0-alpha.12",
+  "desktopVersion": "0.1.0-alpha.13",
   "entries": [
     {
       "id": "web-search",


### PR DESCRIPTION
## 发布目标

将已合并的 Windows/Linux About 菜单修复发布为新的不可变版本 `v0.1.0-alpha.13`。不移动或复用旧标签。

## 变更与边界

- 将 `package.json`、Cargo package/lock、Tauri 配置和可信插件目录同步到 `0.1.0-alpha.13`。
- `@deepseek-ai/dsh` 继续固定为已通过三平台验证的 `0.1.0-rc.6`。
- npm `latest` 当前为 `0.1.1-rc.2`；上游升级需要独立兼容性审查，不混入本次菜单 Bugfix Release。
- 不修改 updater 端点、签名密钥、权限或平台打包配置。

## 验证

- `pnpm check`
- `pnpm test:updater-contract`
- `pnpm test:plugin-catalog`
- `pnpm check:upstream` → pinned `0.1.0-rc.6`, latest `0.1.1-rc.2`, drift `true`（已明确接受本次不升级）

## 发布步骤

1. 三平台 PR CI 通过后 squash merge。
2. 在合并提交创建并推送新标签 `v0.1.0-alpha.13`。
3. 等待生产 Release 的 preflight、四平台构建、原子发布及 update-channel 全部成功。
4. 核对 Release 资产、`latest.json` 与 Windows NSIS 安装包。

Related to #40 and #41.