### PR TITLE
build(deps): bump Tauri plugins, flate2, and action-gh-release

### DIFF
--- a/.github/workflows/update-preview.yml
+++ b/.github/workflows/update-preview.yml
@@ -131,7 +131,7 @@ jobs:
             update-channel/latest.json "$version" "preview-v${version}" \
             update-channel/release.json
       - name: Atomically replace preview channel metadata
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
         with:
           tag_name: preview-channel
           name: DSH Desk preview update channel

--- a/scripts/test-updater-contract.mjs
+++ b/scripts/test-updater-contract.mjs
@@ -207,7 +207,7 @@ for (const token of [
   "node scripts/validate-update-manifest.mjs",
   "tag_name: preview-channel",
   "overwrite_files: true",
-  "softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228",
+  "softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64",
 ]) {
   assert(updatePreviewWorkflow.includes(token), `Update preview workflow is missing ${token}`);
 }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1042,12 +1042,13 @@ checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
 
 [[package]]
 name = "flate2"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.9.1",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -2132,6 +2133,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2639,7 +2650,7 @@ dependencies = [
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
 ]
 
 [[package]]
@@ -2652,7 +2663,7 @@ dependencies = [
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
 ]
 
 [[package]]
@@ -3784,9 +3795,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-dialog"
-version = "2.7.2"
+version = "2.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2d3c1dbe38037e7f590cdf2492594d5ceebe031e7bc7e827509b22a999d2940"
+checksum = "61854a36651aa48381e5e209f69a01273b77f3f9f91f0c430b1b98d33bd47229"
 dependencies = [
  "log",
  "raw-window-handle",
@@ -3802,9 +3813,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-fs"
-version = "2.5.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
+checksum = "de22eef34fd78c0da050e748710edd50bf127e651d02ea1b2bfada1523cc5c51"
 dependencies = [
  "anyhow",
  "dunce",
@@ -3826,9 +3837,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-single-instance"
-version = "2.4.3"
+version = "2.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3214becf9ef5783c0ae99a3bb25adf5353a7a16ebf53e74b909e29205735c6c"
+checksum = "5cd0cb5c412a5071b69bab6a6df1583cbb89460d4a83b6a24769b08d15b6b1e1"
 dependencies = [
  "serde",
  "serde_json",
@@ -5439,6 +5450,12 @@ dependencies = [
  "indexmap 2.14.0",
  "memchr",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tar = "0.4"
 tauri = { version = "2.11.5", features = [] }
-tauri-plugin-dialog = "2.7.2"
+tauri-plugin-dialog = "2.7.3"
 tauri-plugin-single-instance = "2"
 url = "2"
 


### PR DESCRIPTION
## Summary
- Bump `tauri-plugin-dialog` to 2.7.3 so the Rust plugin matches the JS bump in #48
- Bump `tauri-plugin-single-instance` to 2.4.4 and `flate2` to 1.1.10
- Pin `softprops/action-gh-release` to v3.0.3 and update the updater contract so CI can pass

Supersedes #49, #50, #51, and #52.

## Test plan
- [x] `node scripts/test-updater-contract.mjs`
- [x] `cargo check --manifest-path src-tauri/Cargo.toml`
- [ ] CI macOS/Windows/Linux contracts


Made with [Cursor](https://cursor.com)