### PR TITLE
fix: upgrade pnpm 12 with an explicit install-script allowlist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev patchelf
       - uses: pnpm/action-setup@v6
         with:
-          version: 11.21.0
+          version: 12.3.4
       - uses: actions/setup-node@v7
         with:
           node-version: 24

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -31,7 +31,7 @@ jobs:
           libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev patchelf
       - uses: pnpm/action-setup@v6
         with:
-          version: 11.21.0
+          version: 12.3.4
       - uses: actions/setup-node@v7
         with:
           node-version: 24
@@ -60,7 +60,7 @@ jobs:
           libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev patchelf
       - uses: pnpm/action-setup@v6
         with:
-          version: 11.21.0
+          version: 12.3.4
       - uses: actions/setup-node@v7
         with:
           node-version: 24

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -45,7 +45,7 @@ jobs:
           libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev patchelf libfuse2
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
-          version: 11.21.0
+          version: 12.3.4
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24

--- a/.github/workflows/publish-update-channel.yml
+++ b/.github/workflows/publish-update-channel.yml
@@ -42,7 +42,7 @@ jobs:
           libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev patchelf libfuse2
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
-          version: 11.21.0
+          version: 12.3.4
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
           libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev patchelf libfuse2
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
-          version: 11.21.0
+          version: 12.3.4
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24
@@ -93,7 +93,7 @@ jobs:
           libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev patchelf libfuse2
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
-          version: 11.21.0
+          version: 12.3.4
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24
@@ -286,7 +286,7 @@ jobs:
           persist-credentials: false
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
-          version: 11.21.0
+          version: 12.3.4
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24

--- a/.github/workflows/update-preview.yml
+++ b/.github/workflows/update-preview.yml
@@ -46,7 +46,7 @@ jobs:
           libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev patchelf libfuse2
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
-          version: 11.21.0
+          version: 12.3.4
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
@@ -111,7 +111,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
-          version: 11.21.0
+          version: 12.3.4
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ DSH Desk 的边界是桌面生命周期、runtime 分发、更新、诊断、安
 ## 本地验证
 
 ```sh
-npx --yes pnpm@11.21.0 install
+npx --yes pnpm@12.3.4 install
 pnpm check
 pnpm test:rust
 pnpm test:harness-contract

--- a/README.md
+++ b/README.md
@@ -94,11 +94,11 @@ A scheduled workflow also installs the newest npm candidate in an isolated CI wo
 
 ## Development
 
-The development toolchain uses pnpm 11.21.0:
+The development toolchain uses pnpm 12.3.4:
 
 ```sh
-npx --yes pnpm@11.21.0 install
-npx --yes pnpm@11.21.0 exec tauri dev
+npx --yes pnpm@12.3.4 install
+npx --yes pnpm@12.3.4 exec tauri dev
 ```
 
 Run the complete local verification suite:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -115,17 +115,17 @@ DSH Desk 当前不宣称安装包最小：完整离线 runtime 会显著增加�
 
 ## 开发
 
-开发环境固定使用 pnpm 11.21.0：
+开发环境固定使用 pnpm 12.3.4：
 
 ```sh
-npx --yes pnpm@11.21.0 install
-npx --yes pnpm@11.21.0 exec tauri dev
+npx --yes pnpm@12.3.4 install
+npx --yes pnpm@12.3.4 exec tauri dev
 ```
 
 可用 `DSH_DESKTOP_WORKSPACE` 指定 Harness 初始工作目录：
 
 ```sh
-DSH_DESKTOP_WORKSPACE=/path/to/project npx --yes pnpm@11.21.0 exec tauri dev
+DSH_DESKTOP_WORKSPACE=/path/to/project npx --yes pnpm@12.3.4 exec tauri dev
 ```
 
 完整验证：

--- a/package.json
+++ b/package.json
@@ -20,14 +20,15 @@
     "url": "https://github.com/majiayu000/dsh-desk.git"
   },
   "type": "module",
-  "packageManager": "pnpm@11.21.0",
+  "packageManager": "pnpm@12.3.4",
   "scripts": {
     "dev": "vite --host 127.0.0.1 --port 1420",
     "build": "tsc --noEmit && vite build",
     "tauri": "tauri",
-    "check": "pnpm build && pnpm test:desktop-menu && cargo check --manifest-path src-tauri/Cargo.toml",
+    "check": "pnpm test:pnpm-toolchain && pnpm build && pnpm test:desktop-menu && cargo check --manifest-path src-tauri/Cargo.toml",
     "test:rust": "cargo test --manifest-path src-tauri/Cargo.toml",
     "test:desktop-menu": "node scripts/test-desktop-menu-contract.mjs",
+    "test:pnpm-toolchain": "node scripts/test-pnpm-toolchain.mjs",
     "test:harness-contract": "node scripts/test-harness-contract.mjs",
     "test:onboarding-contract": "node scripts/test-onboarding-contract.mjs",
     "test:packaged-runtime": "node scripts/test-harness-contract.mjs --runtime-root resources/runtime",
@@ -62,7 +63,7 @@
     "@deepseek-ai/dsh": "0.1.0-rc.8",
     "@tauri-apps/api": "2.11.1",
     "@tauri-apps/plugin-dialog": "2.7.3",
-    "pnpm": "11.24.0"
+    "pnpm": "12.3.4"
   },
   "devDependencies": {
     "@tauri-apps/cli": "2.11.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,104 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      pnpm:
+        specifier: 12.3.4
+        version: 12.3.4
+
+packages:
+
+  '@pnpm/exe.darwin-arm64@12.3.4':
+    resolution: {integrity: sha512-PAyUol8T1+/+ViOiXAt51ECA+QnfXCqz6foL4bW+LsoX0NcVd5XVEM2mRQu+LV4oc7uRz9zf9U0P+XFfuQeDAw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pnpm/exe.darwin-x64@12.3.4':
+    resolution: {integrity: sha512-fxP9JCk0Cdye+ePuj+GJJLMUMTqHGWRdb1dtv4How876uQ2ehxvenpgiYAir/ceO9PsYUZkFTtyZdx+rRu5QOA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@pnpm/exe.linux-arm64-musl@12.3.4':
+    resolution: {integrity: sha512-FBOt0/7ye6O6q4AllVV5QMviB6qE6fqkeczV/+MDWQsmo+QJrlfsh6X7CpH/tClVpBZEyIbjpUoT8bNhCYBxEg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-arm64@12.3.4':
+    resolution: {integrity: sha512-t71AVA7LRqiKTyZ5xMYaZc2n5DfdpMbfokZuiIOXHBOM03ECnF0t4iYwaBDqJgVjlKYUOwaF/bRQajGNA4cJ4w==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.linux-x64-musl@12.3.4':
+    resolution: {integrity: sha512-RPmk7Jb/aYaFvL2iyDN/AtMY+hUEsue732WmXpcuQ9tBpMnGyA5py7Z3+e+qmQaJ0zY/4ni9jJiyPBQHujmv6w==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-x64@12.3.4':
+    resolution: {integrity: sha512-2ZqOlSPkfwX1h5cR+FPiWf8+F+2hZT/3TvhUK5sigHqwaQCIiq8R7CGxhndKs63JtcLi2a1Qpo+wX/EoyfjyJQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.win32-arm64@12.3.4':
+    resolution: {integrity: sha512-ANyrHqyqco6SXBysUTRF74itDyyraea7IbFsKFdNXTjcFnfycTDx37EwuhdpPYFNSIh2JhUG4fByclsRfiHX7w==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pnpm/exe.win32-x64@12.3.4':
+    resolution: {integrity: sha512-WH/KqBPY/hq2Tb7SgQltEZytimcjgKRaCRL/aM9CI0c67iKc5TVmHUhIiL3Ux9FB4bWn36i6XewUcScQI+zG8w==}
+    cpu: [x64]
+    os: [win32]
+
+  pnpm@12.3.4:
+    resolution: {integrity: sha512-lhqkH7B32joEpEHZ+OFevAyW2o73ELLrZ7+e58sGEOq9SPH9hfUc/+c4RnhfoPh8VqOocqHYk/hEZ0G1zORUVw==}
+    engines: {node: '>=18.*'}
+    hasBin: true
+
+snapshots:
+
+  '@pnpm/exe.darwin-arm64@12.3.4':
+    optional: true
+
+  '@pnpm/exe.darwin-x64@12.3.4':
+    optional: true
+
+  '@pnpm/exe.linux-arm64-musl@12.3.4':
+    optional: true
+
+  '@pnpm/exe.linux-arm64@12.3.4':
+    optional: true
+
+  '@pnpm/exe.linux-x64-musl@12.3.4':
+    optional: true
+
+  '@pnpm/exe.linux-x64@12.3.4':
+    optional: true
+
+  '@pnpm/exe.win32-arm64@12.3.4':
+    optional: true
+
+  '@pnpm/exe.win32-x64@12.3.4':
+    optional: true
+
+  pnpm@12.3.4:
+    optionalDependencies:
+      '@pnpm/exe.darwin-arm64': 12.3.4
+      '@pnpm/exe.darwin-x64': 12.3.4
+      '@pnpm/exe.linux-arm64': 12.3.4
+      '@pnpm/exe.linux-arm64-musl': 12.3.4
+      '@pnpm/exe.linux-x64': 12.3.4
+      '@pnpm/exe.linux-x64-musl': 12.3.4
+      '@pnpm/exe.win32-arm64': 12.3.4
+      '@pnpm/exe.win32-x64': 12.3.4
+
+---
 lockfileVersion: '9.0'
 
 settings:
@@ -19,8 +120,8 @@ importers:
         specifier: 2.7.3
         version: 2.7.3
       pnpm:
-        specifier: 11.24.0
-        version: 11.24.0
+        specifier: 12.3.4
+        version: 12.3.4
     devDependencies:
       '@tauri-apps/cli':
         specifier: 2.11.4
@@ -2483,6 +2584,50 @@ packages:
   '@oxc-project/types@0.144.0':
     resolution: {integrity: sha512-nuhZIOLuI6TFQ32I/WnUx+SCPY7SdSKwgnFHydAuoS1+Z4BRcaP+RRJmGzl9lw+0OFF7UmaESf7KQRXaNLHypg==}
 
+  '@pnpm/exe.darwin-arm64@12.3.4':
+    resolution: {integrity: sha512-PAyUol8T1+/+ViOiXAt51ECA+QnfXCqz6foL4bW+LsoX0NcVd5XVEM2mRQu+LV4oc7uRz9zf9U0P+XFfuQeDAw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pnpm/exe.darwin-x64@12.3.4':
+    resolution: {integrity: sha512-fxP9JCk0Cdye+ePuj+GJJLMUMTqHGWRdb1dtv4How876uQ2ehxvenpgiYAir/ceO9PsYUZkFTtyZdx+rRu5QOA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@pnpm/exe.linux-arm64-musl@12.3.4':
+    resolution: {integrity: sha512-FBOt0/7ye6O6q4AllVV5QMviB6qE6fqkeczV/+MDWQsmo+QJrlfsh6X7CpH/tClVpBZEyIbjpUoT8bNhCYBxEg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-arm64@12.3.4':
+    resolution: {integrity: sha512-t71AVA7LRqiKTyZ5xMYaZc2n5DfdpMbfokZuiIOXHBOM03ECnF0t4iYwaBDqJgVjlKYUOwaF/bRQajGNA4cJ4w==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.linux-x64-musl@12.3.4':
+    resolution: {integrity: sha512-RPmk7Jb/aYaFvL2iyDN/AtMY+hUEsue732WmXpcuQ9tBpMnGyA5py7Z3+e+qmQaJ0zY/4ni9jJiyPBQHujmv6w==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-x64@12.3.4':
+    resolution: {integrity: sha512-2ZqOlSPkfwX1h5cR+FPiWf8+F+2hZT/3TvhUK5sigHqwaQCIiq8R7CGxhndKs63JtcLi2a1Qpo+wX/EoyfjyJQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.win32-arm64@12.3.4':
+    resolution: {integrity: sha512-ANyrHqyqco6SXBysUTRF74itDyyraea7IbFsKFdNXTjcFnfycTDx37EwuhdpPYFNSIh2JhUG4fByclsRfiHX7w==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pnpm/exe.win32-x64@12.3.4':
+    resolution: {integrity: sha512-WH/KqBPY/hq2Tb7SgQltEZytimcjgKRaCRL/aM9CI0c67iKc5TVmHUhIiL3Ux9FB4bWn36i6XewUcScQI+zG8w==}
+    cpu: [x64]
+    os: [win32]
+
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
 
@@ -3528,9 +3673,9 @@ packages:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
 
-  pnpm@11.24.0:
-    resolution: {integrity: sha512-vSfjRel23LC+C3oSKCF7BJqBfiGx81XJDb59xGZxiVqLwebQbCRVRQXqk+oLRfSJon7Bv7yN5qlln8oPFvoAAA==}
-    engines: {node: '>=22.13'}
+  pnpm@12.3.4:
+    resolution: {integrity: sha512-lhqkH7B32joEpEHZ+OFevAyW2o73ELLrZ7+e58sGEOq9SPH9hfUc/+c4RnhfoPh8VqOocqHYk/hEZ0G1zORUVw==}
+    engines: {node: '>=18.*'}
     hasBin: true
 
   postcss@8.5.26:
@@ -6704,6 +6849,30 @@ snapshots:
 
   '@oxc-project/types@0.144.0': {}
 
+  '@pnpm/exe.darwin-arm64@12.3.4':
+    optional: true
+
+  '@pnpm/exe.darwin-x64@12.3.4':
+    optional: true
+
+  '@pnpm/exe.linux-arm64-musl@12.3.4':
+    optional: true
+
+  '@pnpm/exe.linux-arm64@12.3.4':
+    optional: true
+
+  '@pnpm/exe.linux-x64-musl@12.3.4':
+    optional: true
+
+  '@pnpm/exe.linux-x64@12.3.4':
+    optional: true
+
+  '@pnpm/exe.win32-arm64@12.3.4':
+    optional: true
+
+  '@pnpm/exe.win32-x64@12.3.4':
+    optional: true
+
   '@protobufjs/aspromise@1.1.2': {}
 
   '@protobufjs/base64@1.1.2': {}
@@ -7565,7 +7734,16 @@ snapshots:
 
   pkce-challenge@5.0.1: {}
 
-  pnpm@11.24.0: {}
+  pnpm@12.3.4:
+    optionalDependencies:
+      '@pnpm/exe.darwin-arm64': 12.3.4
+      '@pnpm/exe.darwin-x64': 12.3.4
+      '@pnpm/exe.linux-arm64': 12.3.4
+      '@pnpm/exe.linux-arm64-musl': 12.3.4
+      '@pnpm/exe.linux-x64': 12.3.4
+      '@pnpm/exe.linux-x64-musl': 12.3.4
+      '@pnpm/exe.win32-arm64': 12.3.4
+      '@pnpm/exe.win32-x64': 12.3.4
 
   postcss@8.5.26:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,10 @@ allowBuilds:
   '@google/genai': true
   koffi: true
   node-pty: true
+  # pnpm 12's wrapper runs install.js to link the platform native binary.
+  # The packaged runtime launches that binary through bin/pnpm.mjs and must
+  # not download it on first use.
+  pnpm: true
   protobufjs: true
 minimumReleaseAgeExclude:
   - '@deepseek-ai/dsh-agent-default-model@0.1.0-rc.6'

--- a/scripts/prepare-runtime.mjs
+++ b/scripts/prepare-runtime.mjs
@@ -85,7 +85,7 @@ function pruneIncompatibleNativeVariants(modulesRoot) {
   return [relative(modulesRoot, muslVariant).split(sep).join("/")];
 }
 
-try {
+function runPnpm(args, options) {
   const pnpmCli = process.env.npm_execpath;
   if (!pnpmCli || !existsSync(pnpmCli)) {
     throw new Error(
@@ -93,10 +93,14 @@ try {
     );
   }
 
-  const deploy = spawnSync(
-    process.execPath,
+  // pnpm 12's npm_execpath is a native binary. Feeding it to Node parses Mach-O/PE as JS.
+  const jsCli = /\.(cjs|js|mjs)$/i.test(pnpmCli);
+  return spawnSync(jsCli ? process.execPath : pnpmCli, jsCli ? [pnpmCli, ...args] : args, options);
+}
+
+try {
+  const deploy = runPnpm(
     [
-      pnpmCli,
       "--config.node-linker=hoisted",
       "--filter",
       "dsh-desk",

--- a/scripts/prepare-runtime.mjs
+++ b/scripts/prepare-runtime.mjs
@@ -146,18 +146,41 @@ try {
   if (process.platform === "win32") {
     writeFileSync(
       join(toolsBin, "pnpm.cmd"),
-      '@echo off\r\n"%~dp0\\..\\..\\node\\node.exe" "%~dp0\\..\\..\\node_modules\\pnpm\\bin\\pnpm.cjs" %*\r\n',
+      '@echo off\r\n"%~dp0\\..\\..\\node\\node.exe" "%~dp0\\..\\..\\node_modules\\pnpm\\bin\\pnpm.mjs" %*\r\n',
     );
   } else {
     const pnpmLauncher = join(toolsBin, "pnpm");
     writeFileSync(
       pnpmLauncher,
-      '#!/bin/sh\nSCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)\nexec "$SCRIPT_DIR/../../node/bin/node" "$SCRIPT_DIR/../../node_modules/pnpm/bin/pnpm.cjs" "$@"\n',
+      '#!/bin/sh\nSCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)\nexec "$SCRIPT_DIR/../../node/bin/node" "$SCRIPT_DIR/../../node_modules/pnpm/bin/pnpm.mjs" "$@"\n',
     );
     chmodSync(pnpmLauncher, 0o755);
   }
 
   const packageJson = JSON.parse(readFileSync(join(projectRoot, "package.json"), "utf8"));
+  const pnpmEntry = join(bundledModules, "pnpm", "bin", "pnpm.mjs");
+  if (!existsSync(pnpmEntry)) {
+    throw new Error(`Bundled pnpm entry missing: ${pnpmEntry}`);
+  }
+  const pnpmCheck = spawnSync(bundledNode, [pnpmEntry, "--version"], {
+    env: { ...env, COREPACK_ENABLE_NETWORK: "0" },
+    encoding: "utf8",
+  });
+  if (pnpmCheck.error) {
+    throw new Error(`Bundled pnpm could not start: ${pnpmCheck.error.message}`);
+  }
+  if (pnpmCheck.status !== 0) {
+    throw new Error(
+      `Bundled pnpm is not usable offline: ${(pnpmCheck.stderr || pnpmCheck.stdout).trim()}`,
+    );
+  }
+  const bundledPnpmVersion = pnpmCheck.stdout.trim();
+  if (bundledPnpmVersion !== packageJson.dependencies.pnpm) {
+    throw new Error(
+      `Bundled pnpm reported ${bundledPnpmVersion}, package.json pins ${packageJson.dependencies.pnpm}`,
+    );
+  }
+
   writeFileSync(
     join(runtimeRoot, "runtime-manifest.json"),
     `${JSON.stringify({

--- a/scripts/test-plugin-parity.mjs
+++ b/scripts/test-plugin-parity.mjs
@@ -52,7 +52,8 @@ function profileFile(home, name) {
 
 function normalizeLockfileImporter(value) {
   const lines = value.replaceAll("\r\n", "\n").split("\n");
-  const importersIndex = lines.indexOf("importers:");
+  // pnpm 12 writes an env lockfile document first; the project graph is last.
+  const importersIndex = lines.lastIndexOf("importers:");
   if (importersIndex === -1) {
     throw new Error("pnpm-lock.yaml does not contain an importers section");
   }

--- a/scripts/test-pnpm-toolchain.mjs
+++ b/scripts/test-pnpm-toolchain.mjs
@@ -1,0 +1,45 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { assertContract as assert } from "./lib/contract.mjs";
+
+const root = resolve(import.meta.dirname, "..");
+const packageJson = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
+const workspace = readFileSync(join(root, "pnpm-workspace.yaml"), "utf8");
+const pnpmVersion = packageJson.dependencies.pnpm;
+
+assert(typeof pnpmVersion === "string" && pnpmVersion.length > 0, "package.json must pin pnpm");
+assert(
+  packageJson.packageManager === `pnpm@${pnpmVersion}`,
+  "packageManager must match the pnpm dependency pin",
+);
+assert(
+  /^  pnpm: true$/m.test(workspace),
+  "pnpm-workspace.yaml must approve pnpm's install script so the native binary is linked offline",
+);
+
+const workflowDir = join(root, ".github", "workflows");
+for (const name of readdirSync(workflowDir).filter((file) => file.endsWith(".yml"))) {
+  const text = readFileSync(join(workflowDir, name), "utf8");
+  if (!text.includes("pnpm/action-setup")) continue;
+  const blocks = text.split(/- uses: pnpm\/action-setup[^\n]*/).slice(1);
+  assert(blocks.length > 0, `${name} must pin pnpm/action-setup`);
+  for (const [index, block] of blocks.entries()) {
+    const version = block.match(/^\s+version:\s*(\S+)/m)?.[1];
+    assert(
+      version === pnpmVersion,
+      `${name} action-setup #${index + 1} pins ${version}, expected ${pnpmVersion}`,
+    );
+  }
+}
+
+const runtimeLauncher = readFileSync(join(root, "scripts", "prepare-runtime.mjs"), "utf8");
+const pluginManager = readFileSync(join(root, "src-tauri", "src", "plugin_manager.rs"), "utf8");
+for (const [name, source] of [
+  ["prepare-runtime.mjs", runtimeLauncher],
+  ["plugin_manager.rs", pluginManager],
+]) {
+  assert(!source.includes("pnpm.cjs"), `${name} must not launch the pnpm 11 CLI entry`);
+  assert(source.includes("pnpm/bin/pnpm.mjs"), `${name} must launch pnpm 12 through bin/pnpm.mjs`);
+}
+
+console.log(`pnpm toolchain pin ${pnpmVersion} is aligned across package.json, CI, and runtime launchers.`);

--- a/scripts/test-pnpm-toolchain.mjs
+++ b/scripts/test-pnpm-toolchain.mjs
@@ -41,5 +41,9 @@ for (const [name, source] of [
   assert(!source.includes("pnpm.cjs"), `${name} must not launch the pnpm 11 CLI entry`);
   assert(source.includes("pnpm/bin/pnpm.mjs"), `${name} must launch pnpm 12 through bin/pnpm.mjs`);
 }
+assert(
+  runtimeLauncher.includes("jsCli") && runtimeLauncher.includes("runPnpm"),
+  "prepare:runtime must spawn pnpm 12's native CLI directly instead of feeding it to Node",
+);
 
 console.log(`pnpm toolchain pin ${pnpmVersion} is aligned across package.json, CI, and runtime launchers.`);

--- a/src-tauri/src/plugin_manager.rs
+++ b/src-tauri/src/plugin_manager.rs
@@ -23,6 +23,10 @@ const PLUGIN_VALIDATION_TIMEOUT: Duration = Duration::from_secs(60);
 const PLUGIN_REPAIR_TIMEOUT: Duration = Duration::from_secs(300);
 const PLUGIN_REGISTRY_VIEW_TIMEOUT: Duration = Duration::from_secs(60);
 
+fn bundled_pnpm_cli(node_modules: &Path) -> PathBuf {
+    node_modules.join("pnpm/bin/pnpm.mjs")
+}
+
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum PluginAction {
@@ -415,7 +419,7 @@ fn repair_profile(
         .ok_or_else(|| "无法定位内置插件运行环境。".to_string())?;
     let mut command = Command::new(node);
     command
-        .arg(node_modules.join("pnpm/bin/pnpm.cjs"))
+        .arg(bundled_pnpm_cli(node_modules))
         .args(["install", "--frozen-lockfile"])
         .current_dir(profile_dir)
         .env("PATH", path)
@@ -550,7 +554,7 @@ fn read_registry_manifest(
         .ok_or_else(|| "无法定位内置插件运行环境。".to_string())?;
     let mut command = Command::new(node);
     command
-        .arg(node_modules.join("pnpm/bin/pnpm.cjs"))
+        .arg(bundled_pnpm_cli(node_modules))
         .args([
             "view",
             source,


### PR DESCRIPTION
## Summary
- Approve `pnpm` in `allowBuilds` so pnpm 12's `install.js` can link the platform native binary instead of failing with `ERR_PNPM_IGNORED_BUILDS`
- Pin `packageManager`, the bundled `pnpm` dependency, and every `pnpm/action-setup` version to 12.3.4 together
- Launch the packaged runtime through `bin/pnpm.mjs` (pnpm 12 no longer ships `pnpm.cjs`) and fail `prepare:runtime` if that CLI cannot run offline
- Add a toolchain contract so the next Dependabot bump cannot drift the pins or revive `pnpm.cjs`

This replaces the closed #47 bump, which only changed the npm package version.

## Test plan
- [x] `node scripts/test-pnpm-toolchain.mjs`
- [x] `npx pnpm@12.3.4 install --frozen-lockfile`
- [x] `COREPACK_ENABLE_NETWORK=0 node node_modules/pnpm/bin/pnpm.mjs --version` → 12.3.4
- [x] `cargo fmt --check` and `cargo clippy -D warnings`
- [ ] CI macOS/Windows/Linux contracts, including `prepare:runtime`


Made with [Cursor](https://cursor.com)