### PR TITLE
fix(runtime): ignore env overrides in release builds

### DIFF
--- a/src-tauri/src/runtime_resolve.rs
+++ b/src-tauri/src/runtime_resolve.rs
@@ -41,20 +41,16 @@ fn select_runtime_paths(
     development_entry: Option<PathBuf>,
     allow_debug_overrides: bool,
 ) -> RuntimeSelection {
-    if allow_debug_overrides {
-        if let Some(entry) = env_entry {
-            return RuntimeSelection::EnvEntry(entry);
-        }
+    if allow_debug_overrides && let Some(entry) = env_entry {
+        return RuntimeSelection::EnvEntry(entry);
     }
 
     if let Some((node, entry)) = bundled {
         return RuntimeSelection::Bundled { node, entry };
     }
 
-    if allow_debug_overrides {
-        if let Some(entry) = development_entry {
-            return RuntimeSelection::DevelopmentEntry(entry);
-        }
+    if allow_debug_overrides && let Some(entry) = development_entry {
+        return RuntimeSelection::DevelopmentEntry(entry);
     }
 
     RuntimeSelection::Missing

--- a/src-tauri/src/runtime_resolve.rs
+++ b/src-tauri/src/runtime_resolve.rs
@@ -14,14 +14,63 @@ use crate::process_termination::run_command_with_timeout;
 const NODE_PROBE_TIMEOUT: Duration = Duration::from_secs(15);
 const LOGIN_SHELL_PROBE_TIMEOUT: Duration = Duration::from_secs(10);
 
+/// Env entry/node overrides and the development `node_modules` fallback are debug-only.
+/// Release builds must resolve exclusively to the bundled `resource_dir()/runtime` paths.
+fn debug_runtime_overrides_enabled() -> bool {
+    cfg!(debug_assertions)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum RuntimeSelection {
+    /// Debug-only: `DSH_DESKTOP_RUNTIME_ENTRY` short-circuit.
+    EnvEntry(PathBuf),
+    /// Signed/packaged Node + Harness entry under `resource_dir()/runtime`.
+    Bundled { node: PathBuf, entry: PathBuf },
+    /// Debug-only: repo `node_modules` Harness entry.
+    DevelopmentEntry(PathBuf),
+    Missing,
+}
+
+/// Pure path-selection helper so debug and release policy can be unit-tested without AppHandle.
+fn select_runtime_paths(
+    env_entry: Option<PathBuf>,
+    bundled: Option<(PathBuf, PathBuf)>,
+    development_entry: Option<PathBuf>,
+    allow_debug_overrides: bool,
+) -> RuntimeSelection {
+    if allow_debug_overrides {
+        if let Some(entry) = env_entry {
+            return RuntimeSelection::EnvEntry(entry);
+        }
+    }
+
+    if let Some((node, entry)) = bundled {
+        return RuntimeSelection::Bundled { node, entry };
+    }
+
+    if allow_debug_overrides {
+        if let Some(entry) = development_entry {
+            return RuntimeSelection::DevelopmentEntry(entry);
+        }
+    }
+
+    RuntimeSelection::Missing
+}
+
+fn select_env_node(env_node: Option<PathBuf>, allow_debug_overrides: bool) -> Option<PathBuf> {
+    if allow_debug_overrides {
+        env_node
+    } else {
+        None
+    }
+}
+
 pub(super) fn resolve_runtime(
     app: &tauri::AppHandle,
 ) -> Result<(PathBuf, PathBuf), RuntimeFailure> {
-    if let Some(entry) = std::env::var_os("DSH_DESKTOP_RUNTIME_ENTRY") {
-        return Ok((resolve_node(app)?, PathBuf::from(entry)));
-    }
+    let env_entry = std::env::var_os("DSH_DESKTOP_RUNTIME_ENTRY").map(PathBuf::from);
 
-    if let Ok(resource_dir) = app.path().resource_dir() {
+    let bundled = if let Ok(resource_dir) = app.path().resource_dir() {
         let bundled_entry = resource_dir.join("runtime/node_modules/@deepseek-ai/dsh/lib/bin.js");
         let bundled_node = resource_dir.join(if cfg!(windows) {
             "runtime/node/node.exe"
@@ -29,30 +78,48 @@ pub(super) fn resolve_runtime(
             "runtime/node/bin/node"
         });
         if bundled_entry.is_file() && bundled_node.is_file() {
-            validate_node(&bundled_node)?;
-            return Ok((bundled_node, bundled_entry));
+            Some((bundled_node, bundled_entry))
+        } else {
+            None
         }
-    }
+    } else {
+        None
+    };
 
-    if cfg!(debug_assertions) {
+    let development_entry = if debug_runtime_overrides_enabled() {
         let project_root = Path::new(env!("CARGO_MANIFEST_DIR"))
             .parent()
             .expect("src-tauri must have a parent");
-        let development_entry = project_root.join("node_modules/@deepseek-ai/dsh/lib/bin.js");
-        if development_entry.is_file() {
-            return Ok((resolve_node(app)?, development_entry));
-        }
-    }
+        let candidate = project_root.join("node_modules/@deepseek-ai/dsh/lib/bin.js");
+        candidate.is_file().then_some(candidate)
+    } else {
+        None
+    };
 
-    Err(RuntimeFailure {
-        code: "runtime-missing",
-        message: "找不到内置 DeepSeek Harness。请重新安装 DSH Desk。".to_string(),
-    })
+    match select_runtime_paths(
+        env_entry,
+        bundled,
+        development_entry,
+        debug_runtime_overrides_enabled(),
+    ) {
+        RuntimeSelection::EnvEntry(entry) => Ok((resolve_node(app)?, entry)),
+        RuntimeSelection::Bundled { node, entry } => {
+            validate_node(&node)?;
+            Ok((node, entry))
+        }
+        RuntimeSelection::DevelopmentEntry(entry) => Ok((resolve_node(app)?, entry)),
+        RuntimeSelection::Missing => Err(RuntimeFailure {
+            code: "runtime-missing",
+            message: "找不到内置 DeepSeek Harness。请重新安装 DSH Desk。".to_string(),
+        }),
+    }
 }
 
 fn resolve_node(app: &tauri::AppHandle) -> Result<PathBuf, RuntimeFailure> {
-    if let Some(explicit) = std::env::var_os("DSH_DESKTOP_NODE") {
-        let path = PathBuf::from(explicit);
+    if let Some(path) = select_env_node(
+        std::env::var_os("DSH_DESKTOP_NODE").map(PathBuf::from),
+        debug_runtime_overrides_enabled(),
+    ) {
         validate_node(&path)?;
         return Ok(path);
     }
@@ -99,9 +166,16 @@ fn resolve_node(app: &tauri::AppHandle) -> Result<PathBuf, RuntimeFailure> {
         }
     }
 
+    let message = if debug_runtime_overrides_enabled() {
+        "找不到兼容的 Node.js（需要 22.19+ 或 24+）。可设置 DSH_DESKTOP_NODE 指向 Node 可执行文件。"
+            .to_string()
+    } else {
+        "找不到兼容的 Node.js（需要 22.19+ 或 24+）。".to_string()
+    };
+
     Err(RuntimeFailure {
         code: "node-runtime-missing",
-        message: "找不到兼容的 Node.js（需要 22.19+ 或 24+）。可设置 DSH_DESKTOP_NODE 指向 Node 可执行文件。".to_string(),
+        message,
     })
 }
 
@@ -172,4 +246,94 @@ fn validate_node(path: &Path) -> Result<(), RuntimeFailure> {
             version.trim()
         ),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        RuntimeSelection, debug_runtime_overrides_enabled, select_env_node, select_runtime_paths,
+    };
+    use std::path::PathBuf;
+
+    fn bundled_pair() -> (PathBuf, PathBuf) {
+        (
+            PathBuf::from("/App.app/Contents/Resources/runtime/node/bin/node"),
+            PathBuf::from(
+                "/App.app/Contents/Resources/runtime/node_modules/@deepseek-ai/dsh/lib/bin.js",
+            ),
+        )
+    }
+
+    #[test]
+    fn release_selection_ignores_env_entry_outside_bundled_runtime() {
+        let env_entry = PathBuf::from("/tmp/attacker/custom-entry.js");
+        let (bundled_node, bundled_entry) = bundled_pair();
+
+        let selection = select_runtime_paths(
+            Some(env_entry),
+            Some((bundled_node.clone(), bundled_entry.clone())),
+            Some(PathBuf::from("/repo/node_modules/@deepseek-ai/dsh/lib/bin.js")),
+            false,
+        );
+
+        assert_eq!(
+            selection,
+            RuntimeSelection::Bundled {
+                node: bundled_node,
+                entry: bundled_entry,
+            }
+        );
+    }
+
+    #[test]
+    fn release_selection_fails_closed_when_only_env_or_dev_paths_exist() {
+        let selection = select_runtime_paths(
+            Some(PathBuf::from("/tmp/attacker/custom-entry.js")),
+            None,
+            Some(PathBuf::from("/repo/node_modules/@deepseek-ai/dsh/lib/bin.js")),
+            false,
+        );
+        assert_eq!(selection, RuntimeSelection::Missing);
+    }
+
+    #[test]
+    fn debug_selection_prefers_env_entry_before_bundled() {
+        let env_entry = PathBuf::from("/tmp/dev/entry.js");
+        let (bundled_node, bundled_entry) = bundled_pair();
+
+        let selection = select_runtime_paths(
+            Some(env_entry.clone()),
+            Some((bundled_node, bundled_entry)),
+            None,
+            true,
+        );
+
+        assert_eq!(selection, RuntimeSelection::EnvEntry(env_entry));
+    }
+
+    #[test]
+    fn debug_selection_falls_back_to_development_entry() {
+        let development = PathBuf::from("/repo/node_modules/@deepseek-ai/dsh/lib/bin.js");
+        let selection = select_runtime_paths(None, None, Some(development.clone()), true);
+        assert_eq!(selection, RuntimeSelection::DevelopmentEntry(development));
+    }
+
+    #[test]
+    fn release_ignores_env_node_override() {
+        assert_eq!(
+            select_env_node(Some(PathBuf::from("/tmp/attacker/node")), false),
+            None
+        );
+    }
+
+    #[test]
+    fn debug_honors_env_node_override() {
+        let path = PathBuf::from("/opt/homebrew/bin/node");
+        assert_eq!(select_env_node(Some(path.clone()), true), Some(path));
+    }
+
+    #[test]
+    fn debug_assertions_gate_matches_override_policy() {
+        assert_eq!(debug_runtime_overrides_enabled(), cfg!(debug_assertions));
+    }
 }

--- a/src-tauri/src/runtime_resolve.rs
+++ b/src-tauri/src/runtime_resolve.rs
@@ -25,7 +25,10 @@ enum RuntimeSelection {
     /// Debug-only: `DSH_DESKTOP_RUNTIME_ENTRY` short-circuit.
     EnvEntry(PathBuf),
     /// Signed/packaged Node + Harness entry under `resource_dir()/runtime`.
-    Bundled { node: PathBuf, entry: PathBuf },
+    Bundled {
+        node: PathBuf,
+        entry: PathBuf,
+    },
     /// Debug-only: repo `node_modules` Harness entry.
     DevelopmentEntry(PathBuf),
     Missing,
@@ -272,7 +275,9 @@ mod tests {
         let selection = select_runtime_paths(
             Some(env_entry),
             Some((bundled_node.clone(), bundled_entry.clone())),
-            Some(PathBuf::from("/repo/node_modules/@deepseek-ai/dsh/lib/bin.js")),
+            Some(PathBuf::from(
+                "/repo/node_modules/@deepseek-ai/dsh/lib/bin.js",
+            )),
             false,
         );
 
@@ -290,7 +295,9 @@ mod tests {
         let selection = select_runtime_paths(
             Some(PathBuf::from("/tmp/attacker/custom-entry.js")),
             None,
-            Some(PathBuf::from("/repo/node_modules/@deepseek-ai/dsh/lib/bin.js")),
+            Some(PathBuf::from(
+                "/repo/node_modules/@deepseek-ai/dsh/lib/bin.js",
+            )),
             false,
         );
         assert_eq!(selection, RuntimeSelection::Missing);


### PR DESCRIPTION
## Summary
- Gate `DSH_DESKTOP_RUNTIME_ENTRY` and `DSH_DESKTOP_NODE` behind `cfg!(debug_assertions)` so release builds resolve only to bundled `resource_dir()/runtime` Node+entry and fail closed when missing (SECURITY.md / runtime-distribution).
- Extract testable `select_runtime_paths` / `select_env_node` helpers and add unit tests covering release ignore + fail-closed behavior.
- Closes #59

## Test plan
- [x] `cargo test --manifest-path src-tauri/Cargo.toml runtime_resolve -- --nocapture`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --release runtime_resolve -- --nocapture`
- [x] `pnpm test:rust`
- [ ] Confirm release packaging still starts from bundled runtime without env overrides


Made with [Cursor](https://cursor.com)